### PR TITLE
fix: Disable test phone masking to restore caller history

### DIFF
--- a/V2/render.yaml
+++ b/V2/render.yaml
@@ -66,7 +66,7 @@ services:
 
       # QA / Testing
       - key: MASK_TEST_PHONES
-        value: "true"
+        value: "false"
 
       # Keep-alive ping
       - key: RENDER_URL


### PR DESCRIPTION
## Summary

- `MASK_TEST_PHONES=true` was replacing test phone numbers with random `+1555` numbers **before** they reached `getCustomerHistory()`, causing all Supabase lookups to return empty
- Cal.com still found Carl because it matches by attendee name/email, not phone — masking the root cause
- Set `MASK_TEST_PHONES=false` in render.yaml

## Root Cause

```
+12487391087 → maskTestPhone() → +15551234567 → getCustomerHistory() → empty
```

The service role key was working fine (confirmed via /health/detailed). The phone number was being mutated before reaching the Supabase query.

## Test plan

- [ ] Deploy and call from +12487391087
- [ ] Verify `lookup_caller` returns `recentCalls`, `pastAppointments`, and `address` (not just Cal.com data)
- [ ] Verify `service_address` and `zip_code` dynamic vars are populated
- [ ] Verify agent skips asking for address/ZIP for returning callers

🤖 Generated with [Claude Code](https://claude.com/claude-code)