### PR TITLE
fix: PostgREST syntax error in jobs query broke address lookup

### DIFF
--- a/V2/src/services/customer-history.ts
+++ b/V2/src/services/customer-history.ts
@@ -369,7 +369,7 @@ export async function getCustomerHistory(phone: string): Promise<CustomerHistory
   // 3. Get jobs from Supabase (past and upcoming bookings)
   const jobs = await supabaseQuery<JobRecord>(
     "jobs",
-    `customer_phone=eq.${encodeURIComponent(normalizedPhone)}&order=scheduled_at.desc.nulls.last&limit=5`
+    `customer_phone=eq.${encodeURIComponent(normalizedPhone)}&order=scheduled_at.desc.nullslast&limit=5`
   );
 
   if (jobs && jobs.length > 0) {


### PR DESCRIPTION
## Summary

- `order=scheduled_at.desc.nulls.last` is invalid PostgREST syntax (HTTP 400, PGRST100)
- Correct syntax: `nullslast` (one word, no dot)
- This silently killed the `jobs` table query, causing `address`, `zipCode`, and `pastAppointments` to be missing from `lookup_caller` responses
- The other 3 queries (`calls`, `customer_notes`, `emergency_alerts`) were unaffected — they use `order=x.desc` without `nulls.last`

## One-word fix

`nulls.last` → `nullslast` in `V2/src/services/customer-history.ts` line 372

## Test plan

- [ ] Deploy and call from +12487391087
- [ ] Verify `lookup_caller` response includes `address` and `zipCode` fields
- [ ] Verify agent skips asking for ZIP and street address for returning callers
- [ ] Verify `pastAppointments` array is populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)