### PR TITLE
fix: Dashboard call display - dupes, HVAC type, booking detection

### DIFF
--- a/V2/src/services/dashboard.ts
+++ b/V2/src/services/dashboard.ts
@@ -118,78 +118,20 @@ function buildAiSummary(
   state: ConversationState,
   retellData?: RetellPostCallData
 ): string {
-  const parts: string[] = [];
-
-  // Include Retell's AI-generated summary if available
-  if (retellData?.call_analysis?.call_summary) {
-    parts.push(retellData.call_analysis.call_summary);
+  // Prefer Retell's AI-generated call summary — it's a clean narrative.
+  // Issue type, outcome, and revenue are stored in dedicated dashboard fields,
+  // so don't duplicate them here.
+  const callSummary = retellData?.call_analysis?.call_summary;
+  if (callSummary) {
+    return callSummary;
   }
 
-  // Include problem description
+  // Fallback: build summary from state when Retell analysis is unavailable
   if (state.problemDescription) {
-    parts.push(`Issue: ${state.problemDescription}`);
+    return state.problemDescription;
   }
 
-  // Include diagnostic context fields from Problem Clarification phase
-  if (state.problemDuration) {
-    parts.push(`Duration: ${state.problemDuration}`);
-  }
-  if (state.problemOnset) {
-    parts.push(`Onset: ${state.problemOnset}`);
-  }
-  if (state.problemPattern) {
-    parts.push(`Pattern: ${state.problemPattern}`);
-  }
-  if (state.customerAttemptedFixes) {
-    parts.push(`Tried: ${state.customerAttemptedFixes}`);
-  }
-
-  // Include equipment details if captured (formatted nicely)
-  const equipmentParts: string[] = [];
-  if (state.equipmentBrand) equipmentParts.push(state.equipmentBrand);
-  if (state.equipmentType) equipmentParts.push(state.equipmentType);
-  if (state.equipmentLocation || state.equipmentAge) {
-    const details: string[] = [];
-    if (state.equipmentLocation) details.push(state.equipmentLocation);
-    if (state.equipmentAge) details.push(state.equipmentAge);
-    equipmentParts.push(`(${details.join(", ")})`);
-  }
-  if (equipmentParts.length > 0) {
-    parts.push(`Equipment: ${equipmentParts.join(" ")}`);
-  }
-
-  // Include HVAC issue type
-  if (state.hvacIssueType) {
-    parts.push(`Type: ${state.hvacIssueType}`);
-  }
-
-  // Include call outcome
-  if (state.endCallReason) {
-    const outcomeMap: Record<EndCallReason, string> = {
-      completed: "Appointment booked",
-      wrong_number: "Wrong number",
-      callback_later: "Customer requested callback",
-      safety_emergency: "SAFETY EMERGENCY - Customer advised to call 911",
-      urgent_escalation: "Urgent - Escalated to on-call technician",
-      out_of_area: "Out of service area",
-      waitlist_added: "Added to waitlist",
-      customer_hangup: "Customer hung up",
-      sales_lead: "Sales lead - Replacement inquiry",
-      cancelled: "Appointment cancelled",
-      rescheduled: "Appointment rescheduled",
-    };
-    parts.push(`Outcome: ${outcomeMap[state.endCallReason] || state.endCallReason}`);
-  }
-
-  // Include flags
-  if (state.isSafetyEmergency) {
-    parts.push("⚠️ SAFETY EMERGENCY");
-  }
-  if (state.isUrgentEscalation) {
-    parts.push("🔴 URGENT ESCALATION");
-  }
-
-  return parts.join(" | ") || "No summary available";
+  return "No summary available";
 }
 
 /**

--- a/V2/src/types/retell.ts
+++ b/V2/src/types/retell.ts
@@ -328,6 +328,21 @@ export interface RetellPostCallData {
   disconnection_reason?: string;
   /** Dynamic variables collected by the LLM during the call (customer_name, service_address, etc.) */
   collected_dynamic_variables?: Record<string, string>;
+  /** Full transcript including tool call invocations and results */
+  transcript_with_tool_calls?: ToolCallEntry[];
+  /** Dynamic variables set on the LLM at call start (Twilio metadata, etc.) */
+  retell_llm_dynamic_variables?: Record<string, string>;
+}
+
+export interface ToolCallEntry {
+  role: "agent" | "user" | "tool_call_invocation" | "tool_call_result";
+  content?: string;
+  tool_call_id?: string;
+  name?: string;
+  arguments?: string;
+  successful?: boolean;
+  time_sec?: number;
+  type?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary
- **Duplicate leads eliminated**: Only process `call_analyzed` events (skip `call_ended`) — prevents race condition where both events create separate leads 97ms apart
- **HVAC "Odor" false positive fixed**: Safety check question ("any gas smell?") in every transcript was matching the Odor regex. Now only uses `problemDescription`, not full transcript
- **Clean AI summaries**: Replaced pipe-separated concatenation (`"[summary] | Issue: [same summary] | Type: Odor | Outcome: hung up"`) with Retell's clean narrative summary
- **Booking detection from tool calls**: `collected_dynamic_variables` is always empty, so booking status was never detected. Now parses `transcript_with_tool_calls` for `book_service` results with `"booked":true`

## Test plan
- [ ] Make a test call → verify only 1 lead created (not 2)
- [ ] Make a booking call → verify outcome is "completed" and booking_status is "confirmed"
- [ ] Check hvac_issue_type → verify correct classification (not all "Odor")
- [ ] Check ai_summary → verify clean text (no pipe separators)
- [ ] `SELECT original_call_id, count(*) FROM leads GROUP BY original_call_id HAVING count(*) > 1` returns empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)