### PR TITLE
fix: sort Cal.com booking lookup soonest-first to prevent stale times

### DIFF
--- a/V2/src/services/calcom.ts
+++ b/V2/src/services/calcom.ts
@@ -86,16 +86,19 @@ export async function lookupBookingByPhone(phone: string): Promise<LookupResult>
     const data = (await response.json()) as { data?: CalBooking[] };
     const bookings: CalBooking[] = data.data || [];
 
-    // Find booking matching this phone number
-    const matchingBooking = bookings.find((booking) => {
-      return booking.attendees?.some((attendee) => {
-        const attendeePhone = attendee.phone?.replace(/\D/g, "") || "";
-        return (
-          attendeePhone.includes(normalizedPhone) ||
-          normalizedPhone.includes(attendeePhone)
-        );
-      });
-    });
+    // Find all bookings matching this phone number, sorted soonest-first
+    const matchingBookings = bookings
+      .filter((booking) => {
+        return booking.attendees?.some((attendee) => {
+          const attendeePhone = attendee.phone?.replace(/\D/g, "") || "";
+          return (
+            attendeePhone.includes(normalizedPhone) ||
+            normalizedPhone.includes(attendeePhone)
+          );
+        });
+      })
+      .sort((a, b) => new Date(a.start).getTime() - new Date(b.start).getTime());
+    const matchingBooking = matchingBookings[0];
 
     if (matchingBooking) {
       const startDate = new Date(matchingBooking.start);


### PR DESCRIPTION
## Summary
- Fixed `lookupBookingByPhone` in `calcom.ts` returning stale appointment times
- When multiple Cal.com bookings exist for the same phone number, the lookup now sorts by start date ascending and returns the soonest upcoming booking instead of the first arbitrary match

## Root Cause
Cal.com accumulated stale bookings (old ones never cancelled when customer rebooked). The lookup used `.find()` which returned whichever booking Cal.com listed first — often a stale one with the wrong time. This caused the AI agent to tell callers incorrect appointment times.

## Test plan
- [ ] Make a test call, book an appointment, then call again and book a different time
- [ ] Verify the agent reports the newest appointment time, not the old one
- [ ] Verify dashboard and agent report the same time

🤖 Generated with [Claude Code](https://claude.com/claude-code)