### PR TITLE
docs: update documentation for v9 15-state architecture

### DIFF
--- a/V2/CLAUDE.md
+++ b/V2/CLAUDE.md
@@ -184,7 +184,48 @@ The System Prompt is the source of truth for the AI's personality and flow.
 - Service: `src/services/alerts.ts`
 - Uses Twilio. Fallback to console logs if env vars missing.
 
-**Project Structure:**
-- `src/server.ts`: Entry point.
-- `src/controllers/retell.ts`: Handles the webhook routing.
-- `src/functions/*`: Individual tool logic (booking, calendar, etc).
+**Project Structure (Phase 2 decomposition):**
+
+```
+src/
+  server.ts                     # Express setup, middleware, health checks, webhook routing
+  middleware/auth.ts             # Retell webhook signature verification
+  state/conversation-state.ts   # State persistence (Supabase upsert), loop detection
+  extraction/post-call.ts       # Customer name, safety emergency, disconnection reason
+  extraction/urgency.ts         # Urgency inference from transcript context
+  extraction/hvac-issue.ts      # HVAC issue type detection (AC, heating, plumbing, etc.)
+  classification/tags.ts        # 117-tag HVAC taxonomy classification
+  classification/call-type.ts   # Call type + urgency tier mapping for dashboard
+  functions/booking.ts           # book_service webhook logic
+  functions/calendar.ts          # check_calendar_availability webhook logic
+  functions/service-area.ts      # validate_service_area webhook logic
+  functions/index.ts             # Tool function registry
+  services/alerts.ts             # SMS alerts via Twilio (emergency, sales lead)
+  services/calcom.ts             # Cal.com API integration
+  services/customer-history.ts   # Caller lookup, address validation
+  services/dashboard.ts          # Dashboard webhook sync (jobs, calls, alerts)
+  services/priority-detection.ts # Priority color/reason detection
+  services/revenue-estimation.ts # Revenue tier estimation ($$$$, $$$, $$, $)
+  services/supabase.ts           # Supabase client factory
+  types/retell.ts                # ConversationState, Retell API types
+  types/index.ts                 # Shared type exports
+  validation/schemas.ts          # Zod schemas for webhook payloads
+  utils/fetch.ts                 # fetchWithRetry for webhook calls
+  utils/health.ts                # Health check endpoint logic
+  utils/logger.ts                # Pino logger configuration
+```
+
+**Test Structure:**
+```
+src/__tests__/
+  unit/                          # Unit tests for individual modules
+    extraction/post-call.test.ts
+    extraction/urgency.test.ts
+    classification/tags.test.ts
+    classification/call-type.test.ts
+    state/conversation-state.test.ts
+    middleware/auth.test.ts
+    ...
+  integration/
+    webhook-pipeline.test.ts     # End-to-end pipeline simulation (31 tests)
+```

--- a/voice-agent/AGENT-STATUS.md
+++ b/voice-agent/AGENT-STATUS.md
@@ -441,7 +441,26 @@ Fixes from call_34883974e5d7ef5804ba49ce98c analysis:
 - **Booking management**: reschedule, cancel, or status check via `manage_appointment` tool
 - **Intent switching**: any branch can exit into new-issue flow with pre-filled data
 
-## State Flow (v9 — 14 states)
+## State Flow (v9 — 15 states)
+
+### All 15 states:
+```
+1. welcome          — Greet, detect intent (service / non-service / existing customer)
+2. non_service      — Billing, vendor, applicant, pricing (terminal or → safety)
+3. lookup           — Auto-lookup caller by phone (lookup_caller tool)
+4. follow_up        — Callback promise fulfillment (create_callback_request + end_call)
+5. manage_booking   — Reschedule/cancel/status check (manage_appointment + end_call)
+6. safety           — Safety screening (no tools — edges only)
+7. safety_emergency — Terminal: confirmed 911 emergency (end_call only)
+8. service_area     — ZIP validation (end_call for out-of-area)
+9. discovery        — Collect problem, address, name (no tools — edges only)
+10. urgency         — Triage timing/priority (no tools — edges only)
+11. urgency_callback — Terminal: callbacks + sales leads (create_callback_request, send_sales_lead_alert, end_call)
+12. pre_confirm     — Summarize and confirm before booking (no tools — edges only)
+13. booking         — Execute booking (book_service tool)
+14. booking_failed  — Terminal: booking fallback (create_callback_request + end_call)
+15. confirm         — Terminal: appointment confirmed (end_call only)
+```
 
 ### New caller / new issue:
 ```
@@ -456,7 +475,7 @@ welcome → non_service → safety (if pricing caller says "yes, schedule me")
 
 ### High-ticket sales lead (replacement/quote/estimate):
 ```
-welcome → lookup → safety → service_area → discovery → urgency → (sales alert + callback) → end_call
+welcome → lookup → safety → service_area → discovery → urgency → urgency_callback → end_call
 ```
 
 ### Known caller with new issue (fast-track):
@@ -475,23 +494,35 @@ welcome → lookup → follow_up → (resolve or → safety flow)
 welcome → lookup → manage_booking → confirm (or → safety flow for new issue)
 ```
 
-## Testing Status (v9)
+### Safety emergency:
+```
+(any state with safety edge) → safety → safety_emergency → end_call
+```
+
+### Booking failure:
+```
+booking → booking_failed → (callback or end_call)
+```
+
+## Testing Status (v9 — 15 states)
 
 | # | State | Type | Status |
 |---|---|---|---|
 | 1 | welcome | Modified (new intents) | Untested |
-| 2 | non_service | NEW | Untested |
+| 2 | non_service | NEW (v9) | Untested |
 | 3 | lookup | Core | Untested |
 | 4 | follow_up | Modified (callback_type) | Untested |
 | 5 | manage_booking | Core | Untested |
-| 6 | safety | Core | Untested |
-| 7 | service_area | Core | Untested |
-| 8 | discovery | Modified (high-ticket + PM) | Untested |
-| 9 | urgency | Modified (sales lead path) | Untested |
-| 10 | pre_confirm | Core | Untested |
-| 11 | booking | Modified (site contact) | Untested |
-| 12 | booking_failed | Core | Untested |
-| 13 | confirm | Core | Untested |
+| 6 | safety | Structural (no tools, Patch #15) | Untested |
+| 7 | safety_emergency | NEW (Patch #15) | Untested |
+| 8 | service_area | Core | Untested |
+| 9 | discovery | Modified (high-ticket + PM) | Untested |
+| 10 | urgency | Structural (no tools, Patch #18) | Untested |
+| 11 | urgency_callback | NEW (Patch #18) | Untested |
+| 12 | pre_confirm | Core | Untested |
+| 13 | booking | Modified (site contact) | Untested |
+| 14 | booking_failed | Core | Untested |
+| 15 | confirm | Core | Untested |
 
 ## New Tools
 

--- a/voice-agent/TEST-SCENARIOS.md
+++ b/voice-agent/TEST-SCENARIOS.md
@@ -1,60 +1,129 @@
-# TEST SCENARIOS (v5-dispatcher)
+# TEST SCENARIOS (v9-triage — 15 states)
 
-Each scenario includes: goal, sample caller lines, expected path.
+Each scenario includes: goal (state path), sample caller lines, expected behavior.
 
----
-
-## 1) Normal Direct Booking (Happy Path)
-**Goal:** 1 → 2 → 4 → 5 → 6 → 7 → 8 → 12
-**Caller:** "Schedule service. No AC — blowing warm since yesterday. ZIP 78745."
-**Expected:** Safety passes → ZIP accepted → discovery (2 Qs) → slots → booking success → confirm.
-
----
-
-## 2) Urgent, No Same-Day → Callback
-**Goal:** 5 → 6 (no same-day) → 9 → 12
-**Caller:** "No AC and it's 105. I need today."
-**Expected:** Calendar offers callback within hour when no same-day.
+State reference:
+```
+1.welcome  2.non_service  3.lookup  4.follow_up  5.manage_booking
+6.safety  7.safety_emergency  8.service_area  9.discovery  10.urgency
+11.urgency_callback  12.pre_confirm  13.booking  14.booking_failed  15.confirm
+```
 
 ---
 
-## 3) Booking Tool Fails → Callback
-**Goal:** 6 → 7 (tool failure) → 9 → 12
-**Caller:** Picks "tomorrow at 9."
-**Expected:** Booking attempts tool; on failure: "not able to finalize…" then callback.
+## 1) New Caller — Full Booking (Happy Path)
+**Path:** welcome → lookup → safety → service_area → discovery → urgency → pre_confirm → booking → confirm
+**Caller:** "My AC stopped cooling this morning. ZIP 78745. 123 Elm Street."
+**Expected:** Lookup finds no record → safety clear → ZIP accepted → collects problem/address/name → urgency routes to booking → pre_confirm summarizes → booking succeeds → confirm with end_call.
 
 ---
 
-## 4) Confirmation Catches Missed Booking → Back-transition
-**Goal:** 8 detects tool not called → back to 7
-**Caller:** "Wait—are we actually confirmed?"
-**Expected:** Agent returns to booking state and locks it in before confirming.
+## 2) Safety Emergency (Gas Smell)
+**Path:** welcome → lookup → safety → safety_emergency
+**Caller:** "I smell gas near my furnace."
+**Expected:** Safety detects emergency → transitions to safety_emergency → instructs caller to call 911 → end_call(safety_emergency). No booking attempt.
 
 ---
 
-## 5) Safety Emergency (Gas Smell)
-**Goal:** 2 → 3
-**Caller:** "I smell gas by the furnace."
-**Expected:** Immediate safety line; no further questions.
-
----
-
-## 6) Out-of-Area Caller (ZIP Rejection)
-**Goal:** 4 → 12
+## 3) Out-of-Area Caller (ZIP Rejection)
+**Path:** welcome → lookup → safety → service_area → end_call
 **Caller:** ZIP "78613" or "77002"
-**Expected:** Honest testing language: "only servicing Austin 787 ZIP codes while we test."
+**Expected:** ZIP not in 787xx range → polite decline → end_call from service_area.
 
 ---
 
-## 7) Wrong Number / Vendor
-**Goal:** 1 → 12
-**Caller A:** "Wrong number."
-**Caller B:** "We sell SEO/leads."
-**Expected:** Polite wrong-number close; firm vendor rejection.
+## 4) Booking Fails → Callback
+**Path:** welcome → lookup → safety → service_area → discovery → urgency → pre_confirm → booking → booking_failed
+**Caller:** Picks "tomorrow at 9 AM" but book_service returns error.
+**Expected:** Booking tool fails → transitions to booking_failed → create_callback_request → end_call.
 
 ---
 
-## 8) Existing Appointment Inquiry
-**Goal:** 1 → 10
-**Caller:** "I have an appointment tomorrow — what time?"
-**Expected:** Routes to existing_customer flow; cleaner "Let me pull up your info."
+## 5) High-Ticket Sales Lead
+**Path:** welcome → lookup → safety → service_area → discovery → urgency → urgency_callback
+**Caller:** "I need a whole new AC system installed."
+**Expected:** Discovery sets lead_type=high_ticket → urgency routes to urgency_callback → send_sales_lead_alert → create_callback_request(type=estimate) → end_call. No diagnostic booking.
+
+---
+
+## 6) Non-Service — Billing Inquiry
+**Path:** welcome → non_service → end_call
+**Caller:** "I have a question about my bill."
+**Expected:** Welcome detects billing intent → non_service → create_callback_request(type=billing) → end_call. No safety question asked.
+
+---
+
+## 7) Non-Service — Vendor Call
+**Path:** welcome → non_service → end_call
+**Caller:** "We sell HVAC parts and wanted to talk to the owner."
+**Expected:** Welcome detects vendor → non_service → polite decline → end_call.
+
+---
+
+## 8) Non-Service — Pricing → Schedules Service
+**Path:** welcome → non_service → safety → (normal booking flow)
+**Caller:** "How much does a service call cost?" then "Yes, go ahead and schedule."
+**Expected:** Pricing answer ($89 diagnostic) → caller accepts → transitions to safety → continues normal booking flow.
+
+---
+
+## 9) Known Caller — New Issue (Fast-Track)
+**Path:** welcome → lookup → safety → service_area* → discovery* → urgency → pre_confirm → booking → confirm
+**Caller:** Return caller with ZIP/address on file. "My heater is making a loud noise."
+**Expected:** Lookup finds existing record → name confirmed → service_area skipped (ZIP known) → discovery skips name/address (pre-filled) → normal booking flow.
+
+---
+
+## 10) Known Caller — Follow-Up
+**Path:** welcome → lookup → follow_up
+**Caller:** "You guys were supposed to call me back about a quote."
+**Expected:** Lookup finds history → follow_up acknowledges prior interaction → create_callback_request(type=follow_up) → end_call.
+
+---
+
+## 11) Known Caller — Manage Existing Booking
+**Path:** welcome → lookup → manage_booking → confirm
+**Caller:** "I need to reschedule my appointment."
+**Expected:** Lookup finds booking → manage_booking calls manage_appointment → reschedule succeeds → confirm with end_call.
+
+---
+
+## 12) Known Caller — Cancel Booking
+**Path:** welcome → lookup → manage_booking → confirm
+**Caller:** "I need to cancel my appointment."
+**Expected:** manage_booking calls manage_appointment(cancel) → cancellation confirmed → confirm with end_call.
+
+---
+
+## 13) Property Manager Call
+**Path:** (normal booking flow through discovery)
+**Caller:** "I'm a property manager, my tenant's AC is out. I won't be at the property."
+**Expected:** Discovery detects PM language → asks for site contact name/phone → captures site_contact_name and site_contact_phone → booking appends site contact to issue_description.
+
+---
+
+## 14) Urgent — Caller Wants Callback Only
+**Path:** welcome → lookup → safety → service_area → discovery → urgency → urgency_callback
+**Caller:** "My AC is broken. Just have someone call me back."
+**Expected:** Urgency detects callback preference → routes to urgency_callback → create_callback_request(type=service) → end_call. No booking attempt.
+
+---
+
+## 15) Wrong Number
+**Path:** welcome → non_service → end_call
+**Caller:** "Sorry, wrong number."
+**Expected:** Welcome detects wrong number → non_service → polite close → end_call.
+
+---
+
+## Validation Checklist
+
+For each test call, verify:
+- [ ] State transitions follow expected path (no backward transitions)
+- [ ] No "transitioning" language spoken aloud
+- [ ] No fabricated bookings (confirm only after successful book_service)
+- [ ] Safety question asked for all service callers
+- [ ] end_call only available in terminal states (safety_emergency, urgency_callback, booking_failed, confirm, non_service, follow_up, manage_booking, welcome)
+- [ ] Urgency state has NO tools (edges only)
+- [ ] Safety state has NO tools (edges only)
+- [ ] Customer data (name, address, ZIP) flows through transitions without re-asking


### PR DESCRIPTION
## Summary
- **AGENT-STATUS.md**: Updated state flow section from 14 to 15 states (added `urgency_callback` from Patch #18 and `safety_emergency` from Patch #15). Updated testing status table to list all 15 states with correct types.
- **TEST-SCENARIOS.md**: Full rewrite from v5-dispatcher to v9-triage. 15 scenarios covering all state paths (happy path, safety emergency, out-of-area, booking failure, sales lead, non-service intents, known callers, property manager, callback-only). Added validation checklist.
- **V2/CLAUDE.md**: Updated project structure to reflect Phase 2 module decomposition (`extraction/`, `classification/`, `state/`, `middleware/`, `validation/`, `utils/`) and test structure.

## Test plan
- [x] V2 test suite passes (85 tests, 7 files)
- [ ] Verify state flow matches deployed `retell-llm-v9-triage.json`
- [ ] Verify test scenarios cover all 15 states

🤖 Generated with [Claude Code](https://claude.com/claude-code)