### PR TITLE
fix: fire SMS when backend infers callbackType

### DIFF
--- a/V2/src/server.ts
+++ b/V2/src/server.ts
@@ -564,6 +564,19 @@ app.post("/webhook/retell/call-ended", async (req: Request, res: Response) => {
       !conversationState.appointmentBooked
     ) {
       conversationState.callbackType = "service";
+
+      // Fire the SMS that create_callback would have sent
+      try {
+        await sendEmergencyAlert({
+          urgencyDescription: `Callback requested: booking failed, agent promised callback`,
+          callerPhone: conversationState.customerPhone || "Unknown",
+          address: conversationState.serviceAddress || "Not provided",
+          callbackMinutes: 60,
+        });
+        logger.info({ callId }, "Inferred callback SMS sent");
+      } catch (smsError) {
+        logger.warn({ callId, error: smsError }, "Inferred callback SMS failed (non-fatal)");
+      }
     }
 
     // Level 1 instrumentation: call quality scorecard


### PR DESCRIPTION
## Summary
- When the voice agent skips `create_callback` and uses `end_call` directly after a failed booking, the backend now sends the same SMS notification that `create_callback` would have sent
- Ensures business owners get real-time alerts for inferred callback calls (booking failures where the agent promised a callback)
- Non-fatal: SMS failure is logged as a warning but doesn't block call processing

## Test plan
- [x] All 175 vitest tests pass
- [x] TypeScript compiles with no errors
- [ ] Verify SMS fires on next real booking-failure call

🤖 Generated with [Claude Code](https://claude.com/claude-code)