### PR TITLE
fix: call analysis fixes — timezone, CONFIRM flow, DISCOVERY boundary, urgency keywords

### DIFF
--- a/V2/src/functions/__tests__/booking.test.ts
+++ b/V2/src/functions/__tests__/booking.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { formatBookingTime } from "../booking.js";
+
+describe("formatBookingTime", () => {
+  it("formats UTC time as America/Chicago timezone", () => {
+    // 2026-02-25T15:00:00Z (3 PM UTC) = 9:00 AM CST
+    const result = formatBookingTime("2026-02-25T15:00:00.000Z");
+    expect(result.timeStr).toBe("9:00 AM");
+    expect(result.dateStr).toContain("Wednesday");
+    expect(result.dateStr).toContain("February");
+    expect(result.dateStr).toContain("25");
+  });
+
+  it("formats CST offset time correctly", () => {
+    // 2026-02-25T09:00:00-06:00 = 9:00 AM CST
+    const result = formatBookingTime("2026-02-25T09:00:00-06:00");
+    expect(result.timeStr).toBe("9:00 AM");
+  });
+
+  it("handles afternoon times", () => {
+    // 2026-02-25T20:00:00Z (8 PM UTC) = 2:00 PM CST
+    const result = formatBookingTime("2026-02-25T20:00:00.000Z");
+    expect(result.timeStr).toBe("2:00 PM");
+  });
+});

--- a/V2/src/functions/booking.ts
+++ b/V2/src/functions/booking.ts
@@ -7,6 +7,27 @@ import { fetchWithRetry, FetchError } from "../utils/fetch.js";
 
 const log = createModuleLogger("booking");
 
+/**
+ * Format an ISO datetime for Austin, TX (America/Chicago).
+ * Always uses CST/CDT regardless of server timezone.
+ */
+export function formatBookingTime(isoDate: string): { dateStr: string; timeStr: string } {
+  const dt = new Date(isoDate);
+  const dateStr = dt.toLocaleDateString("en-US", {
+    weekday: "long",
+    month: "long",
+    day: "numeric",
+    timeZone: "America/Chicago",
+  });
+  const timeStr = dt.toLocaleTimeString("en-US", {
+    hour: "numeric",
+    minute: "2-digit",
+    hour12: true,
+    timeZone: "America/Chicago",
+  });
+  return { dateStr, timeStr };
+}
+
 const CAL_COM_API_KEY = process.env.CAL_COM_API_KEY;
 const CAL_COM_EVENT_TYPE_ID = process.env.CAL_COM_EVENT_TYPE_ID || "3877847";
 const CAL_API_BASE = "https://api.cal.com/v2";
@@ -117,17 +138,7 @@ async function createCalComBooking(
   log.info({ bookingUid: data.data.uid }, "Cal.com booking created");
 
   // Parse the booking response
-  const startTime = new Date(data.data.startTime);
-  const dateStr = startTime.toLocaleDateString("en-US", {
-    weekday: "long",
-    month: "long",
-    day: "numeric",
-  });
-  const timeStr = startTime.toLocaleTimeString("en-US", {
-    hour: "numeric",
-    minute: "2-digit",
-    hour12: true,
-  });
+  const { dateStr, timeStr } = formatBookingTime(data.data.startTime);
 
   return {
     success: true,
@@ -146,17 +157,7 @@ function generateMockBookingConfirmation(
 ): BookAppointmentResult {
   const appointmentId = `apt_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
 
-  const dateTime = new Date(params.dateTime);
-  const dateStr = dateTime.toLocaleDateString("en-US", {
-    weekday: "long",
-    month: "long",
-    day: "numeric",
-  });
-  const timeStr = dateTime.toLocaleTimeString("en-US", {
-    hour: "numeric",
-    minute: "2-digit",
-    hour12: true,
-  });
+  const { dateStr, timeStr } = formatBookingTime(params.dateTime);
 
   log.info({ appointmentId }, "Generated mock booking");
 

--- a/docs/plans/2026-02-24-call-quality-fixes-round2-design.md
+++ b/docs/plans/2026-02-24-call-quality-fixes-round2-design.md
@@ -1,0 +1,67 @@
+# Call Quality Fixes Round 2 — Design
+
+**Date:** 2026-02-24
+**Call analyzed:** CA446d05699f041290d963302bc94587e9 (145.6s, ended in CONFIRM)
+**Branch:** rbaset5/urgency-state-fixes
+
+## Context
+
+Round 1 fixes (PR #67) addressed: em dash in canned TTS, ambiguous "no" in CONFIRM close signals, StartFrame noise filter, callback promise data surfacing. This round addresses what worked, what didn't, and new bugs found from a production call.
+
+## Round 1 Fix Status
+
+| Fix | Status | Evidence |
+|-----|--------|----------|
+| Remove "no"/"nope"/"nah" from CONFIRM_CLOSE_SIGNALS | WORKS | User said "No." → routed to LLM, not canned close |
+| Em dash removed from canned TTS strings | WORKS | No UTF-8 codec errors |
+| Callback promise in KNOWN INFO | WORKS | Prompt contains callback data |
+| StartFrame noise filter | BROKEN | 50+ StartFrame errors still flood logs; filter targets stdlib logging but pipecat uses loguru |
+| Callback promise acknowledgment | BROKEN | SAFETY prompt says "after safety check" but state machine transitions before LLM can deliver |
+
+## Bugs to Fix
+
+### Bug 1: StartFrame noise filter targets wrong logging framework
+
+**Symptom:** 50+ `StartFrame not received` ERROR lines per call in Fly.io logs.
+**Root cause:** `bot.py` applies `logging.Filter` to stdlib `logging.getLogger("pipecat.processors.frame_processor")`. Pipecat uses loguru internally. The filter has zero effect.
+**Fix:** Use loguru's native filter API. Add a filter function to loguru that suppresses messages containing "StartFrame not received" from the `pipecat.processors.frame_processor` module.
+
+### Bug 2: Call ending is irrevocable after CONFIRM Turn 2
+
+**Symptom:** User said "No" to "Anything else?" then wanted to ask a follow-up question. Agent was already speaking goodbye; call ended.
+**Root cause:** `_handle_confirm` returns `Action(end_call=True, needs_llm=True)` on Turn 2. `_delayed_end_call(delay=3.0)` fires as a fire-and-forget asyncio task. No cancellation mechanism exists.
+**Fix:** Store the delayed end task handle on the processor. If a new TranscriptionFrame arrives while the delay is active, cancel it, reset CONFIRM state to allow one more exchange, and process the new input.
+
+### Bug 3: 27-second dead air between DISCOVERY and URGENCY question
+
+**Symptom:** User said "Hello?" twice waiting for the urgency question. LLM wasted a turn generating a summary before asking.
+**Root cause:** After DISCOVERY auto-transitions to URGENCY with canned "Got it." (`needs_llm=False`), the next user input triggers an LLM call. The LLM generates a recap instead of the urgency question, wasting a turn.
+**Fix:** When DISCOVERY detects all fields collected and transitions to URGENCY, emit a canned urgency question directly: "Got it. How urgent is this - need someone today, or this week works?" This eliminates the LLM latency entirely.
+
+### Bug 4: Callback promise acknowledgment never delivered
+
+**Symptom:** Lookup returned `callbackPromise: {date: "today", issue: "being really loud"}`. Agent never mentioned it.
+**Root cause:** SAFETY prompt says "acknowledge AFTER safety check" but state machine transitions to SERVICE_AREA immediately after "No." The LLM never gets another SAFETY turn.
+**Fix:** Move callback acknowledgment to the URGENCY prompt. URGENCY is the first LLM-generated state after the deterministic SERVICE_AREA/DISCOVERY flow, making it the natural place for the acknowledgment.
+
+### Bug 5: LLM-generated em dashes are a latent TTS crash risk
+
+**Symptom:** LLM generated `—` in SAFETY and URGENCY responses. Inworld TTS processed them without error this time, but the UTF-8 chunk boundary issue is stochastic.
+**Fix:** Add a text sanitizer in the processor that replaces `—` with `-` in all text before it reaches TTS. Apply to both LLM-generated text and any other text frames.
+
+## Architecture
+
+All fixes are in `pipecat-agent/src/calllock/`:
+
+| File | Changes |
+|------|---------|
+| `bot.py` | Replace stdlib logging filter with loguru filter |
+| `processor.py` | Cancellable `_delayed_end_call`; em dash sanitizer on outbound text |
+| `state_machine.py` | DISCOVERY→URGENCY canned question; CONFIRM Turn 3 support |
+| `prompts.py` | Move callback acknowledgment from SAFETY to URGENCY |
+
+## Non-Goals
+
+- Fixing ZIP code misinterpretation ("Five two one one" as address vs ZIP) — this is a transcription/UX issue, not a state machine bug
+- Fixing the "wrap sound" transcription — Deepgram STT limitation
+- Changing the two-turn CONFIRM flow fundamentally — the cancellable delay is sufficient

--- a/docs/plans/2026-02-24-call-quality-fixes-round2-plan.md
+++ b/docs/plans/2026-02-24-call-quality-fixes-round2-plan.md
@@ -1,12 +1,21 @@
-# Call Quality Fixes Round 2 — Implementation Plan
+# Call Quality Fixes Round 2 — Implementation Plan (v1.1)
 
 > **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
 
 **Goal:** Fix 5 bugs found in production call CA446d...587e9: broken StartFrame filter, irrevocable call ending, 27s dead air gap, missing callback acknowledgment, latent em dash crash risk.
 
-**Architecture:** All changes are in `pipecat-agent/src/calllock/`. State machine gets two behavioral changes (DISCOVERY canned urgency question, CONFIRM cancellable end). Processor gets cancellable delayed end + em dash sanitizer. Bot.py gets loguru filter. Prompts.py moves callback acknowledgment.
+**Architecture:** All changes are in `pipecat-agent/src/calllock/`. State machine gets a merged canned urgency question + callback acknowledgment in DISCOVERY. Processor gets cancellable delayed end with bounded re-cancellation. TTS fallback gets em dash sanitizer. Bot.py gets loguru filter. Prompts.py removes unreachable callback instruction from SAFETY.
 
 **Tech Stack:** Python 3.13, pipecat-ai, loguru, pytest, pytest-asyncio
+
+**Review changes (v1.0 → v1.1):**
+- Tasks 2+4 merged: canned urgency question now includes conditional callback ack (fully deterministic)
+- `TextSanitizer` pipeline processor eliminated; sanitization moved to `FallbackTTSService.run_tts`
+- `callback_promise` type changed from `str` to `dict` for clean rendering
+- `URGENCY_QUESTION` extracted as module constant (DRY)
+- `confirm_extended` flag bounds cancellation to exactly 1 re-try
+- `logger.remove(0)` instead of `logger.remove()` (less destructive)
+- 7 tests added (filter: 3, cancellation: 2, extended flag: 2)
 
 ---
 
@@ -14,21 +23,43 @@
 
 **Files:**
 - Modify: `pipecat-agent/src/calllock/bot.py:12-18`
+- Test: `pipecat-agent/tests/test_bot.py` (new file)
 
-**Context:** The current filter uses `logging.getLogger().addFilter()` (stdlib), but pipecat logs via loguru. The filter has zero effect. Loguru's `logger.remove()` + `logger.add(filter=...)` is the correct API.
+**Context:** The current filter uses `logging.getLogger().addFilter()` (stdlib), but pipecat logs via loguru. The filter has zero effect. Loguru's `logger.remove(0)` + `logger.add(filter=...)` is the correct API.
 
-**Step 1: Write the failing test**
+**Step 1: Write the failing tests**
 
-No unit test needed — this is a logging configuration fix. The "test" is verifying loguru filter behavior inline.
+Create `pipecat-agent/tests/test_bot.py`:
 
-**Step 2: Replace stdlib filter with loguru filter**
+```python
+from calllock.bot import _startframe_noise_filter
+
+
+class TestStartFrameNoiseFilter:
+    def test_suppresses_startframe_from_frame_processor(self):
+        record = {"name": "pipecat.processors.frame_processor", "message": "InworldHttpTTSService#0 Trying to process TTSTextFrame but StartFrame not received yet"}
+        assert _startframe_noise_filter(record) is False
+
+    def test_allows_real_errors_from_frame_processor(self):
+        record = {"name": "pipecat.processors.frame_processor", "message": "Real error in frame processing"}
+        assert _startframe_noise_filter(record) is True
+
+    def test_allows_startframe_text_from_other_modules(self):
+        record = {"name": "calllock.processor", "message": "StartFrame not received"}
+        assert _startframe_noise_filter(record) is True
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cd pipecat-agent && pytest tests/test_bot.py -v`
+Expected: FAIL — `_startframe_noise_filter` not importable (doesn't exist yet as a standalone function).
+
+**Step 3: Replace stdlib filter with loguru filter**
 
 In `bot.py`, replace lines 12-18:
 
 ```python
 # OLD (broken — targets stdlib, pipecat uses loguru):
-# Suppress Pipecat "StartFrame not received" cosmetic noise that floods Fly.io log buffer.
-# Uses a targeted filter (not setLevel) to preserve real frame processor errors.
 class _StartFrameNoiseFilter(logging.Filter):
     def filter(self, record: logging.LogRecord) -> bool:
         return "StartFrame not received" not in record.getMessage()
@@ -36,46 +67,89 @@ class _StartFrameNoiseFilter(logging.Filter):
 logging.getLogger("pipecat.processors.frame_processor").addFilter(_StartFrameNoiseFilter())
 ```
 
+With:
+
 ```python
-# NEW (targets loguru, which pipecat actually uses):
+# Suppress Pipecat "StartFrame not received" cosmetic noise that floods Fly.io log buffer.
+# Pipecat uses loguru (not stdlib logging), so we must filter at the loguru level.
 import sys
 from loguru import logger as _loguru
 
 def _startframe_noise_filter(record):
-    """Suppress Pipecat 'StartFrame not received' cosmetic noise from Fly.io log buffer."""
+    """Suppress 'StartFrame not received' from pipecat.processors.frame_processor only."""
     if record["name"] == "pipecat.processors.frame_processor":
         return "StartFrame not received" not in record["message"]
     return True
 
-_loguru.remove()  # Remove default handler (ID 0)
-_loguru.add(sys.stderr, filter=_startframe_noise_filter, level="DEBUG", format="{time:YYYY-MM-DD HH:mm:ss.SSS} | {level: <8} | {name}:{function}:{line} - {message}")
+try:
+    _loguru.remove(0)  # Remove default handler only (not other sinks)
+except ValueError:
+    pass  # Already removed by another module
+_loguru.add(sys.stderr, filter=_startframe_noise_filter, level="DEBUG",
+            format="{time:YYYY-MM-DD HH:mm:ss.SSS} | {level: <8} | {name}:{function}:{line} - {message}")
 ```
 
-**Step 3: Run existing tests to verify no regression**
+**Step 4: Run tests**
+
+Run: `cd pipecat-agent && pytest tests/test_bot.py -v`
+Expected: PASS (all 3 tests)
+
+**Step 5: Run full test suite**
 
 Run: `cd pipecat-agent && pytest tests/ -x -q`
-Expected: All tests pass (no change to business logic).
+Expected: All tests pass.
 
-**Step 4: Commit**
+**Step 6: Commit**
 
 ```bash
-git add pipecat-agent/src/calllock/bot.py
+git add pipecat-agent/src/calllock/bot.py pipecat-agent/tests/test_bot.py
 git commit -m "fix: use loguru filter for StartFrame noise (pipecat uses loguru, not stdlib)"
 ```
 
 ---
 
-### Task 2: DISCOVERY → URGENCY canned question (eliminate 27s gap)
+### Task 2: DISCOVERY canned urgency question + callback acknowledgment (eliminate 27s gap)
 
 **Files:**
-- Modify: `pipecat-agent/src/calllock/state_machine.py:236-247`
+- Modify: `pipecat-agent/src/calllock/state_machine.py:236-247` (handler + constant)
+- Modify: `pipecat-agent/src/calllock/session.py:19` (callback_promise type)
+- Modify: `pipecat-agent/src/calllock/prompts.py:176-193,227-237` (SAFETY cleanup + URGENCY prompt)
 - Test: `pipecat-agent/tests/test_state_machine.py`
+- Test: `pipecat-agent/tests/test_prompts.py`
 
-**Context:** When DISCOVERY detects all fields collected, it transitions to URGENCY with canned "Got it." and `needs_llm=False`. The next user input triggers an LLM call in URGENCY, but the LLM wastes a turn generating a summary instead of asking the urgency question. Fix: combine "Got it." with the urgency question in one canned speak.
+**Context:** This task merges the original Tasks 2 and 4 from v1.0. DISCOVERY auto-transitioning to URGENCY with just "Got it." caused a 27s dead air gap (LLM wasted a turn on a summary). The callback acknowledgment in the SAFETY prompt was unreachable (state machine transitions before LLM fires). Fix: emit both callback ack and urgency question as one deterministic canned speak from `_handle_discovery`.
 
-**Step 1: Write the failing test**
+**Step 1: Change `callback_promise` type to dict**
 
-Add to `TestDiscoveryState` class in `test_state_machine.py`:
+In `session.py`, change line 19:
+
+```python
+# OLD:
+callback_promise: str = ""
+
+# NEW:
+callback_promise: dict = field(default_factory=dict)
+```
+
+**Step 2: Update `_build_context` to render dict cleanly**
+
+In `prompts.py`, change the callback_promise rendering (line 98-99):
+
+```python
+# OLD:
+if session.callback_promise:
+    parts.append(f"We owe this caller a callback: {session.callback_promise}")
+
+# NEW:
+if session.callback_promise:
+    issue = session.callback_promise.get("issue", "unknown issue")
+    date = session.callback_promise.get("date", "")
+    parts.append(f"We owe this caller a callback about {issue}" + (f" (from {date})" if date else ""))
+```
+
+**Step 3: Write failing tests**
+
+Add to `TestDiscoveryState` in `test_state_machine.py`:
 
 ```python
 def test_all_fields_collected_emits_urgency_question(self, sm, session):
@@ -87,211 +161,71 @@ def test_all_fields_collected_emits_urgency_question(self, sm, session):
     action = sm.process(session, "")
     assert session.state == State.URGENCY
     assert action.needs_llm is False
-    assert "urgent" in action.speak.lower() or "today" in action.speak.lower()
+    assert "today" in action.speak.lower()
+
+def test_all_fields_with_callback_promise_includes_ack(self, sm, session):
+    """When callback promise exists, canned speak should acknowledge it."""
+    session.state = State.DISCOVERY
+    session.customer_name = "Jonas"
+    session.problem_description = "AC blowing warm air"
+    session.service_address = "4210 South Lamar Blvd"
+    session.callback_promise = {"date": "today", "issue": "being really loud"}
+    action = sm.process(session, "")
+    assert session.state == State.URGENCY
+    assert "callback" in action.speak.lower()
+    assert "being really loud" in action.speak.lower()
+    assert "today" in action.speak.lower()  # urgency question still present
 ```
 
-**Step 2: Run test to verify it fails**
+**Step 4: Run tests to verify they fail**
 
-Run: `cd pipecat-agent && pytest tests/test_state_machine.py::TestDiscoveryState::test_all_fields_collected_emits_urgency_question -v`
-Expected: FAIL — current `action.speak` is just "Got it." which doesn't contain "urgent" or "today".
+Run: `cd pipecat-agent && pytest tests/test_state_machine.py::TestDiscoveryState::test_all_fields_collected_emits_urgency_question tests/test_state_machine.py::TestDiscoveryState::test_all_fields_with_callback_promise_includes_ack -v`
+Expected: FAIL — current speak is just "Got it."
 
-**Step 3: Update _handle_discovery**
+**Step 5: Add constant and update `_handle_discovery`**
 
-In `state_machine.py`, change `_handle_discovery` (line 246):
+In `state_machine.py`, add constant near line 113 (after BOOKING_LANGUAGE):
+
+```python
+URGENCY_QUESTION = "How urgent is this - need someone today, or this week works?"
+```
+
+Update `_handle_discovery` (line 244-246):
 
 ```python
 # OLD:
+_transition(session, State.URGENCY)
 return Action(speak="Got it.", needs_llm=False)
 
 # NEW:
-return Action(
-    speak="Got it. How urgent is this - need someone today, or this week works?",
-    needs_llm=False,
-)
+_transition(session, State.URGENCY)
+# Build canned speak: callback ack (if owed) + urgency question
+parts = ["Got it."]
+if session.callback_promise:
+    issue = session.callback_promise.get("issue", "a previous issue") if isinstance(session.callback_promise, dict) else "a previous issue"
+    parts.append(f"I also see we owe you a callback about {issue} - we'll make sure that gets handled too.")
+parts.append(URGENCY_QUESTION)
+return Action(speak=" ".join(parts), needs_llm=False)
 ```
 
-**Step 4: Run test to verify it passes**
+**Step 6: Remove callback ack from SAFETY prompt, update URGENCY prompt**
 
-Run: `cd pipecat-agent && pytest tests/test_state_machine.py::TestDiscoveryState::test_all_fields_collected_emits_urgency_question -v`
-Expected: PASS
-
-**Step 5: Run full test suite**
-
-Run: `cd pipecat-agent && pytest tests/ -x -q`
-Expected: All tests pass. The existing `test_all_fields_routes_to_urgency` still passes (it only checks state, not speak).
-
-**Step 6: Commit**
-
-```bash
-git add pipecat-agent/src/calllock/state_machine.py pipecat-agent/tests/test_state_machine.py
-git commit -m "fix: emit canned urgency question from DISCOVERY to eliminate 27s dead air gap"
-```
-
----
-
-### Task 3: Make _delayed_end_call cancellable (fix "1 more question")
-
-**Files:**
-- Modify: `pipecat-agent/src/calllock/processor.py:44-63,159,228,250-253`
-- Test: `pipecat-agent/tests/test_processor.py`
-
-**Context:** `_delayed_end_call` creates a fire-and-forget asyncio task. If the user speaks again during the delay, nothing can cancel it. Fix: store the task handle; cancel it if a new transcription arrives; re-enter the state machine with the new input.
-
-**Step 1: Write the failing test**
-
-Add to `test_processor.py`:
+In `prompts.py`, remove from SAFETY prompt (lines 191-193):
 
 ```python
-class TestCancellableDelayedEnd:
-    """If user speaks again during delayed end, cancel the end and process new input."""
-
-    @pytest.mark.asyncio
-    async def test_new_transcription_cancels_delayed_end(self, processor):
-        """Speech during goodbye delay should cancel the end and process the new input."""
-        # Set up CONFIRM state, turn 2 (end_call=True, needs_llm=True)
-        processor.session.state = State.CONFIRM
-        processor.session.booking_confirmed = True
-        processor.session.confirmation_message = "Appointment confirmed for Wednesday at 3 PM"
-        # Simulate first turn
-        processor.session.state_turn_count = 1
-        processor.session.agent_has_responded = True
-
-        # Process "No." — this triggers _delayed_end_call
-        await processor.process_frame(
-            TranscriptionFrame(text="No.", user_id="", timestamp=""),
-            FrameDirection.DOWNSTREAM,
-        )
-
-        # Verify delayed end task was created
-        assert processor._end_call_task is not None
-        assert not processor._end_call_task.done()
-
-        # Now user speaks again before delay expires
-        await processor.process_frame(
-            TranscriptionFrame(text="Actually, how much is the diagnostic?", user_id="", timestamp=""),
-            FrameDirection.DOWNSTREAM,
-        )
-
-        # The old delayed end should be cancelled
-        assert processor._end_call_task is None or processor._end_call_task.cancelled()
+# DELETE these lines:
+CALLBACK ACKNOWLEDGMENT:
+If KNOWN INFO mentions we owe this caller a callback, briefly acknowledge it AFTER the safety check:
+"I also see we owe you a callback about [issue] - we'll make sure that gets handled too."
 ```
 
-**Step 2: Run test to verify it fails**
+Update URGENCY prompt to reference the constant's wording (for the LLM fallback path when fields aren't all known from lookup):
 
-Run: `cd pipecat-agent && pytest tests/test_processor.py::TestCancellableDelayedEnd::test_new_transcription_cancels_delayed_end -v`
-Expected: FAIL — `processor._end_call_task` attribute doesn't exist.
-
-**Step 3: Implement cancellable delayed end**
-
-In `processor.py`:
-
-3a. Add `_end_call_task` to `__init__` (after line 62):
-```python
-self._end_call_task: asyncio.Task | None = None
-```
-
-3b. Replace all `asyncio.create_task(self._delayed_end_call(...))` calls (lines 159, 228, 292) with:
-```python
-self._end_call_task = asyncio.create_task(self._delayed_end_call(delay=3.0))
-```
-(Keep the 4.0 delay on line 292 for terminal responses.)
-
-3c. Add cancellation logic at the top of `_handle_transcription` (after line 172, before state machine call):
-```python
-# Cancel pending delayed end if user speaks again
-if self._end_call_task and not self._end_call_task.done():
-    self._end_call_task.cancel()
-    self._end_call_task = None
-    logger.info(f"[{self.session.state.value}] Cancelled delayed end — user spoke again")
-```
-
-3d. Update `_delayed_end_call` to clear the reference after firing (line 250-253):
-```python
-async def _delayed_end_call(self, delay: float = 3.0):
-    """Push EndFrame after a delay to allow TTS to finish speaking."""
-    await asyncio.sleep(delay)
-    self._end_call_task = None
-    await self.push_frame(EndFrame(), FrameDirection.DOWNSTREAM)
-```
-
-**Step 4: Run test to verify it passes**
-
-Run: `cd pipecat-agent && pytest tests/test_processor.py::TestCancellableDelayedEnd -v`
-Expected: PASS
-
-**Step 5: Run full test suite**
-
-Run: `cd pipecat-agent && pytest tests/ -x -q`
-Expected: All tests pass.
-
-**Step 6: Commit**
-
-```bash
-git add pipecat-agent/src/calllock/processor.py pipecat-agent/tests/test_processor.py
-git commit -m "fix: make _delayed_end_call cancellable so user can still speak during goodbye"
-```
-
----
-
-### Task 4: Move callback acknowledgment from SAFETY to URGENCY prompt
-
-**Files:**
-- Modify: `pipecat-agent/src/calllock/prompts.py:176-193,227-237`
-- Test: `pipecat-agent/tests/test_prompts.py`
-
-**Context:** SAFETY prompt says "acknowledge callback AFTER safety check" but the state machine transitions to SERVICE_AREA immediately after the user answers "No." The LLM never gets another SAFETY turn. URGENCY is the first LLM-generated state after the deterministic SERVICE_AREA/DISCOVERY flow.
-
-**Step 1: Write the failing test**
-
-Add to `test_prompts.py`:
-
-```python
-def test_urgency_prompt_includes_callback_acknowledgment(self):
-    """URGENCY prompt should acknowledge pending callback promise."""
-    session = CallSession(phone_number="+15125551234")
-    session.state = State.URGENCY
-    session.callback_promise = {"date": "today", "issue": "being really loud"}
-    prompt = get_system_prompt(session)
-    assert "callback" in prompt.lower()
-    assert "being really loud" in prompt.lower() or "callback" in prompt.lower()
-```
-
-**Step 2: Run test to verify it fails**
-
-Run: `cd pipecat-agent && pytest tests/test_prompts.py::test_urgency_prompt_includes_callback_acknowledgment -v`
-Expected: FAIL — URGENCY prompt doesn't mention callbacks. (Note: the callback data IS in KNOWN INFO via `_build_context`, but the URGENCY state prompt doesn't instruct the LLM to acknowledge it.)
-
-Actually, looking at the code again — `_build_context` (line 98-99) already includes `"We owe this caller a callback: ..."` in KNOWN INFO for ALL states. So the data is present. The issue is the URGENCY prompt doesn't tell the LLM to acknowledge it. Let me refine:
-
-```python
-def test_urgency_prompt_instructs_callback_acknowledgment(self):
-    """URGENCY state prompt text should tell LLM to acknowledge pending callback."""
-    session = CallSession(phone_number="+15125551234")
-    session.state = State.URGENCY
-    session.callback_promise = {"date": "today", "issue": "being really loud"}
-    prompt = get_system_prompt(session)
-    # The STATE_PROMPTS[URGENCY] text (not just KNOWN INFO) should mention callback
-    assert "callback" in STATE_PROMPTS[State.URGENCY].lower() or "owe" in STATE_PROMPTS[State.URGENCY].lower()
-```
-
-**Step 3: Update prompts**
-
-3a. Remove callback acknowledgment section from SAFETY prompt (lines 191-193):
-```python
-# REMOVE from State.SAFETY prompt:
-# CALLBACK ACKNOWLEDGMENT:
-# If KNOWN INFO mentions we owe this caller a callback, briefly acknowledge it AFTER the safety check:
-# "I also see we owe you a callback about [issue] - we'll make sure that gets handled too."
-```
-
-3b. Add callback acknowledgment to URGENCY prompt (line 237):
 ```python
 State.URGENCY: """## URGENCY
 Determine scheduling priority.
 
-If KNOWN INFO mentions we owe this caller a callback, acknowledge it first:
-"I also see we owe you a callback about [issue] - we'll make sure that gets handled too."
-Then ask about urgency.
+If KNOWN INFO mentions we owe this caller a callback, acknowledge it briefly first.
 
 If timing is ALREADY CLEAR from what they said:
 "ASAP" / "today" / "right away" -> urgent
@@ -303,135 +237,279 @@ If timing is UNCLEAR:
 Do NOT say the time "works" or is "available" - you haven't checked the calendar yet.""",
 ```
 
-**Step 4: Run test to verify it passes**
+**Step 7: Update prompt tests**
 
-Run: `cd pipecat-agent && pytest tests/test_prompts.py -v`
-Expected: PASS
+In `test_prompts.py`, update `TestCallbackPromiseInSafety` class to reflect the change:
 
-**Step 5: Run full test suite**
+```python
+class TestCallbackPromiseRendering:
+    """Callback promise should render cleanly in KNOWN INFO."""
+
+    def test_callback_promise_renders_issue(self):
+        session = CallSession(phone_number="+15125551234")
+        session.state = State.SAFETY
+        session.callback_promise = {"date": "today", "issue": "being really loud"}
+        prompt = get_system_prompt(session)
+        assert "being really loud" in prompt
+        assert "callback" in prompt.lower()
+
+    def test_callback_promise_empty_dict_excluded(self):
+        session = CallSession(phone_number="+15125551234")
+        session.state = State.SAFETY
+        session.callback_promise = {}
+        prompt = get_system_prompt(session)
+        assert "we owe this caller" not in prompt.lower()
+
+    def test_safety_prompt_no_longer_has_callback_instruction(self):
+        """SAFETY prompt should NOT contain callback acknowledgment instruction (moved to canned speak)."""
+        from calllock.prompts import STATE_PROMPTS
+        assert "CALLBACK ACKNOWLEDGMENT" not in STATE_PROMPTS[State.SAFETY]
+```
+
+**Step 8: Run all tests**
 
 Run: `cd pipecat-agent && pytest tests/ -x -q`
-Expected: All tests pass.
+Expected: All pass. Some existing tests referencing `callback_promise` as string may need updating.
 
-**Step 6: Commit**
+**Step 9: Commit**
 
 ```bash
-git add pipecat-agent/src/calllock/prompts.py pipecat-agent/tests/test_prompts.py
-git commit -m "fix: move callback acknowledgment from SAFETY to URGENCY prompt where LLM can deliver it"
+git add pipecat-agent/src/calllock/state_machine.py pipecat-agent/src/calllock/session.py pipecat-agent/src/calllock/prompts.py pipecat-agent/tests/test_state_machine.py pipecat-agent/tests/test_prompts.py
+git commit -m "fix: canned urgency question + callback ack from DISCOVERY (eliminates 27s gap)"
 ```
 
 ---
 
-### Task 5: Em dash sanitizer for LLM-generated TTS text
+### Task 3: Make _delayed_end_call cancellable with bounded retry (fix "1 more question")
 
 **Files:**
-- Modify: `pipecat-agent/src/calllock/processor.py:64-75`
+- Modify: `pipecat-agent/src/calllock/processor.py:44-63,159,228,250-253`
+- Modify: `pipecat-agent/src/calllock/session.py` (add `confirm_extended` field)
 - Test: `pipecat-agent/tests/test_processor.py`
+- Test: `pipecat-agent/tests/test_state_machine.py`
 
-**Context:** The LLM generates em dashes (`—`) in responses. Inworld TTS can crash with UTF-8 codec errors when em dashes land on streaming chunk boundaries. Fix: intercept all text going to TTS and replace em dashes with plain dashes.
+**Context:** `_delayed_end_call` creates a fire-and-forget asyncio task. If the user speaks again during the delay, nothing can cancel it. Fix: store the task handle; cancel it if a new transcription arrives. Bound to exactly one cancellation via `confirm_extended` flag.
 
-**Step 1: Write the failing test**
+**Step 1: Add `confirm_extended` to CallSession**
+
+In `session.py`, add after `terminal_reply_used` (line 51):
+
+```python
+confirm_extended: bool = False  # True after first delayed-end cancellation in CONFIRM
+```
+
+**Step 2: Write the failing tests**
 
 Add to `test_processor.py`:
 
 ```python
-class TestEmDashSanitizer:
-    """Em dashes in LLM output should be replaced before reaching TTS."""
+class TestCancellableDelayedEnd:
+    """If user speaks again during delayed end, cancel the end and process new input."""
 
     @pytest.mark.asyncio
-    async def test_em_dash_replaced_in_tts_speak_frame(self, processor):
-        """TTSSpeakFrame text should have em dashes replaced with plain dashes."""
-        from pipecat.frames.frames import TTSSpeakFrame
+    async def test_first_cancellation_succeeds_and_processes_input(self, processor):
+        """First speech during goodbye delay should cancel end and push frame downstream."""
+        processor.session.state = State.CONFIRM
+        processor.session.booking_confirmed = True
+        processor.session.confirmation_message = "Appointment confirmed for Wednesday at 3 PM"
+        processor.session.state_turn_count = 1
+        processor.session.agent_has_responded = True
 
-        processor.session.state = State.SAFETY
-        # Simulate a transcription that triggers a canned speak with em dash
-        # We test via process_frame pushing a TTSSpeakFrame through
-        frames_pushed = []
-        original_push = processor.push_frame
-
-        async def capture_push(frame, direction=FrameDirection.DOWNSTREAM):
-            frames_pushed.append(frame)
-            # Don't actually push downstream
-
-        processor.push_frame = capture_push
-
-        # Process a transcription that would generate a response
+        # Process "No." — triggers _delayed_end_call
         await processor.process_frame(
-            TranscriptionFrame(text="no gas smell", user_id="", timestamp=""),
+            TranscriptionFrame(text="No.", user_id="", timestamp=""),
+            FrameDirection.DOWNSTREAM,
+        )
+        assert processor._end_call_task is not None
+        assert not processor._end_call_task.done()
+
+        # User speaks again before delay expires
+        processor.session.agent_has_responded = True
+        await processor.process_frame(
+            TranscriptionFrame(text="Actually, how much is the diagnostic?", user_id="", timestamp=""),
             FrameDirection.DOWNSTREAM,
         )
 
-        # Check that any TTSSpeakFrame pushed has no em dashes
-        for frame in frames_pushed:
-            if isinstance(frame, TTSSpeakFrame):
-                assert "\u2014" not in frame.text  # em dash
-                assert "\u2013" not in frame.text  # en dash
+        # Delayed end should be cancelled, confirm_extended set
+        assert processor._end_call_task is None or processor._end_call_task.cancelled()
+        assert processor.session.confirm_extended is True
+
+        # The new transcription should have been pushed downstream (frame containing "diagnostic")
+        pushed_frames = [call.args[0] for call in processor.push_frame.call_args_list]
+        transcription_pushed = any(
+            isinstance(f, TranscriptionFrame) and "diagnostic" in f.text
+            for f in pushed_frames
+        )
+        assert transcription_pushed, "New transcription should be pushed downstream"
+
+    @pytest.mark.asyncio
+    async def test_second_cancellation_blocked(self, processor):
+        """After one cancellation, subsequent speech should NOT cancel delayed end."""
+        processor.session.state = State.CONFIRM
+        processor.session.booking_confirmed = True
+        processor.session.confirmation_message = "Appointment confirmed for Wednesday at 3 PM"
+        processor.session.state_turn_count = 1
+        processor.session.agent_has_responded = True
+        processor.session.confirm_extended = True  # Already used the one cancellation
+
+        # Process input — triggers _delayed_end_call
+        await processor.process_frame(
+            TranscriptionFrame(text="Thanks.", user_id="", timestamp=""),
+            FrameDirection.DOWNSTREAM,
+        )
+
+        if processor._end_call_task:
+            task_before = processor._end_call_task
+            # User speaks again — but extended already used
+            processor.session.agent_has_responded = True
+            await processor.process_frame(
+                TranscriptionFrame(text="Wait one more thing", user_id="", timestamp=""),
+                FrameDirection.DOWNSTREAM,
+            )
+            # Should NOT have cancelled — task still the same or a new one (from re-trigger)
+            # The key assertion: confirm_extended is still True, no reset
+            assert processor.session.confirm_extended is True
 ```
 
-**Step 2: Run test to verify current behavior**
+**Step 3: Add `_end_call_task` to processor.__init__**
 
-Run: `cd pipecat-agent && pytest tests/test_processor.py::TestEmDashSanitizer -v`
-Expected: May pass if no canned speaks have em dashes (they were already fixed). But the sanitizer protects against LLM-generated em dashes too.
+In `processor.py`, add after line 62 (`self._buffer_start_time`):
 
-**Step 3: Add sanitizer to process_frame**
-
-In `processor.py`, add a helper method and modify `process_frame` to sanitize outbound text frames:
-
-3a. Add helper (after `__init__`):
 ```python
-@staticmethod
-def _sanitize_tts_text(text: str) -> str:
-    """Replace em/en dashes with plain dashes to prevent Inworld TTS UTF-8 chunk errors."""
-    return text.replace("\u2014", "-").replace("\u2013", "-")
+self._end_call_task: asyncio.Task | None = None
 ```
 
-3b. Override `push_frame` to sanitize TTSSpeakFrame text before pushing:
+**Step 4: Replace fire-and-forget with stored task**
 
-Actually, the cleaner approach is to sanitize at the two points where we create TTSSpeakFrame:
-- Line 202: `await self.push_frame(TTSSpeakFrame(text=action.speak), ...)`
-- Line 276: `await self.push_frame(TTSSpeakFrame(text=reply), ...)`
-- Line 285: `await self.push_frame(TTSSpeakFrame(text=canned), ...)`
+Replace all 3 instances of `asyncio.create_task(self._delayed_end_call(...))`:
 
-Replace each `TTSSpeakFrame(text=X)` with `TTSSpeakFrame(text=self._sanitize_tts_text(X))`.
+Line 159 (buffer flush path):
+```python
+self._end_call_task = asyncio.create_task(self._delayed_end_call(delay=3.0))
+```
 
-But we also need to catch LLM-generated text. The LLM output flows downstream as TextFrame through the context aggregator → LLM → TTS, bypassing this processor. So the sanitizer needs to be in the pipeline AFTER the LLM and BEFORE TTS.
+Line 228 (normal path):
+```python
+self._end_call_task = asyncio.create_task(self._delayed_end_call(delay=3.0))
+```
 
-Simpler approach: add a small `TextSanitizer` frame processor between LLM and TTS in the pipeline. Let's add it to `pipeline.py` instead.
+Line 292 (terminal response path):
+```python
+self._end_call_task = asyncio.create_task(self._delayed_end_call(delay=4.0))
+```
 
-**Revised approach — sanitize in pipeline.py:**
+**Step 5: Add cancellation logic to _handle_transcription**
 
-3c. Create a simple sanitizer processor. Add to `processor.py` (bottom of file):
+After line 172 (the `logger.info` for caller text), before `# Buffer mode:` check:
 
 ```python
-class TextSanitizer(FrameProcessor):
-    """Replace em/en dashes in all text frames to prevent TTS UTF-8 errors."""
-
-    async def process_frame(self, frame: Frame, direction: FrameDirection):
-        await super().process_frame(frame, direction)
-        if isinstance(frame, TextFrame) and frame.text:
-            frame = TextFrame(text=frame.text.replace("\u2014", "-").replace("\u2013", "-"))
-        elif isinstance(frame, TTSSpeakFrame) and frame.text:
-            frame = TTSSpeakFrame(text=frame.text.replace("\u2014", "-").replace("\u2013", "-"))
-        await self.push_frame(frame, direction)
+# Cancel pending delayed end if user speaks again (one chance only)
+if self._end_call_task and not self._end_call_task.done():
+    if not self.session.confirm_extended:
+        self._end_call_task.cancel()
+        self._end_call_task = None
+        self.session.confirm_extended = True
+        logger.info(f"[{self.session.state.value}] Cancelled delayed end - user spoke again")
 ```
 
-3d. Insert `TextSanitizer()` in the pipeline between LLM and TTS in `pipeline.py`. Find where the pipeline list is assembled and add it after the LLM output.
+**Step 6: Update _delayed_end_call to clear reference**
 
-**Step 4: Run tests**
+```python
+async def _delayed_end_call(self, delay: float = 3.0):
+    """Push EndFrame after a delay to allow TTS to finish speaking."""
+    await asyncio.sleep(delay)
+    self._end_call_task = None
+    await self.push_frame(EndFrame(), FrameDirection.DOWNSTREAM)
+```
+
+**Step 7: Run tests**
+
+Run: `cd pipecat-agent && pytest tests/test_processor.py::TestCancellableDelayedEnd -v`
+Expected: PASS
 
 Run: `cd pipecat-agent && pytest tests/ -x -q`
-Expected: All tests pass.
+Expected: All pass.
 
-**Step 5: Commit**
+**Step 8: Commit**
 
 ```bash
-git add pipecat-agent/src/calllock/processor.py pipecat-agent/src/calllock/pipeline.py pipecat-agent/tests/test_processor.py
-git commit -m "fix: sanitize em/en dashes before TTS to prevent UTF-8 chunk boundary crashes"
+git add pipecat-agent/src/calllock/processor.py pipecat-agent/src/calllock/session.py pipecat-agent/tests/test_processor.py
+git commit -m "fix: cancellable _delayed_end_call with confirm_extended bound (1 retry max)"
 ```
 
 ---
 
-### Task 6: Final verification and deploy
+### Task 4: Em dash sanitizer in FallbackTTSService
+
+**Files:**
+- Modify: `pipecat-agent/src/calllock/tts_fallback.py:107-114`
+- Test: `pipecat-agent/tests/test_tts_fallback.py` (new or existing)
+
+**Context:** The LLM generates em dashes (`—`) in responses. Inworld TTS can crash with UTF-8 codec errors when em dashes land on streaming chunk boundaries. Fix: sanitize text in `run_tts` before passing to primary/fallback TTS. This is 3 lines in an existing file — no new pipeline processor.
+
+**Step 1: Write the failing test**
+
+Create or add to TTS fallback tests:
+
+```python
+import pytest
+from calllock.tts_fallback import FallbackTTSService
+
+
+class TestTTSSanitization:
+    def test_em_dash_sanitized(self):
+        """Em dashes should be replaced with plain dashes before TTS."""
+        text = "Quick safety check \u2014 any gas smell?"
+        sanitized = text.replace("\u2014", "-").replace("\u2013", "-")
+        assert "\u2014" not in sanitized
+        assert "Quick safety check - any gas smell?" == sanitized
+
+    def test_en_dash_sanitized(self):
+        """En dashes should also be replaced."""
+        text = "Monday \u2013 Friday"
+        sanitized = text.replace("\u2014", "-").replace("\u2013", "-")
+        assert "Monday - Friday" == sanitized
+
+    def test_plain_text_unchanged(self):
+        """Text without special dashes should pass through unchanged."""
+        text = "Got it. How urgent is this - need someone today?"
+        sanitized = text.replace("\u2014", "-").replace("\u2013", "-")
+        assert text == sanitized
+```
+
+**Step 2: Add sanitization to `run_tts`**
+
+In `tts_fallback.py`, update `run_tts` (line 107):
+
+```python
+async def run_tts(self, text: str, context_id: str) -> AsyncGenerator[Frame, None]:
+    # Sanitize em/en dashes to prevent Inworld TTS UTF-8 chunk boundary errors
+    text = text.replace("\u2014", "-").replace("\u2013", "-")
+
+    if self._circuit.should_try():
+        async for frame in self._try_primary(text, context_id):
+            yield frame
+    else:
+        logger.info("Circuit breaker open — using fallback TTS directly")
+        async for frame in self._run_fallback(text, context_id):
+            yield frame
+```
+
+**Step 3: Run tests**
+
+Run: `cd pipecat-agent && pytest tests/ -x -q`
+Expected: All pass.
+
+**Step 4: Commit**
+
+```bash
+git add pipecat-agent/src/calllock/tts_fallback.py pipecat-agent/tests/test_tts_fallback.py
+git commit -m "fix: sanitize em/en dashes in TTS to prevent UTF-8 chunk boundary crashes"
+```
+
+---
+
+### Task 5: Final verification and deploy
 
 **Step 1: Run full test suite**
 
@@ -458,7 +536,8 @@ Expected: No StartFrame lines (filter working).
 
 **Step 6: Make a test call and verify**
 
-- Call should acknowledge callback promise during urgency question
-- DISCOVERY → URGENCY should be instant (canned question, no LLM delay)
-- Saying "No" then speaking again should cancel the goodbye
+- Callback promise acknowledged in canned speak (deterministic, not LLM-dependent)
+- DISCOVERY → URGENCY instant (canned question, no LLM delay)
+- Saying "No" then speaking again cancels the goodbye and processes input
+- Second cancellation attempt doesn't extend the call further
 - No em dash TTS crashes in logs

--- a/docs/plans/2026-02-24-call-quality-fixes-round2-plan.md
+++ b/docs/plans/2026-02-24-call-quality-fixes-round2-plan.md
@@ -1,0 +1,464 @@
+# Call Quality Fixes Round 2 — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Fix 5 bugs found in production call CA446d...587e9: broken StartFrame filter, irrevocable call ending, 27s dead air gap, missing callback acknowledgment, latent em dash crash risk.
+
+**Architecture:** All changes are in `pipecat-agent/src/calllock/`. State machine gets two behavioral changes (DISCOVERY canned urgency question, CONFIRM cancellable end). Processor gets cancellable delayed end + em dash sanitizer. Bot.py gets loguru filter. Prompts.py moves callback acknowledgment.
+
+**Tech Stack:** Python 3.13, pipecat-ai, loguru, pytest, pytest-asyncio
+
+---
+
+### Task 1: Fix StartFrame noise filter (loguru)
+
+**Files:**
+- Modify: `pipecat-agent/src/calllock/bot.py:12-18`
+
+**Context:** The current filter uses `logging.getLogger().addFilter()` (stdlib), but pipecat logs via loguru. The filter has zero effect. Loguru's `logger.remove()` + `logger.add(filter=...)` is the correct API.
+
+**Step 1: Write the failing test**
+
+No unit test needed — this is a logging configuration fix. The "test" is verifying loguru filter behavior inline.
+
+**Step 2: Replace stdlib filter with loguru filter**
+
+In `bot.py`, replace lines 12-18:
+
+```python
+# OLD (broken — targets stdlib, pipecat uses loguru):
+# Suppress Pipecat "StartFrame not received" cosmetic noise that floods Fly.io log buffer.
+# Uses a targeted filter (not setLevel) to preserve real frame processor errors.
+class _StartFrameNoiseFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        return "StartFrame not received" not in record.getMessage()
+
+logging.getLogger("pipecat.processors.frame_processor").addFilter(_StartFrameNoiseFilter())
+```
+
+```python
+# NEW (targets loguru, which pipecat actually uses):
+import sys
+from loguru import logger as _loguru
+
+def _startframe_noise_filter(record):
+    """Suppress Pipecat 'StartFrame not received' cosmetic noise from Fly.io log buffer."""
+    if record["name"] == "pipecat.processors.frame_processor":
+        return "StartFrame not received" not in record["message"]
+    return True
+
+_loguru.remove()  # Remove default handler (ID 0)
+_loguru.add(sys.stderr, filter=_startframe_noise_filter, level="DEBUG", format="{time:YYYY-MM-DD HH:mm:ss.SSS} | {level: <8} | {name}:{function}:{line} - {message}")
+```
+
+**Step 3: Run existing tests to verify no regression**
+
+Run: `cd pipecat-agent && pytest tests/ -x -q`
+Expected: All tests pass (no change to business logic).
+
+**Step 4: Commit**
+
+```bash
+git add pipecat-agent/src/calllock/bot.py
+git commit -m "fix: use loguru filter for StartFrame noise (pipecat uses loguru, not stdlib)"
+```
+
+---
+
+### Task 2: DISCOVERY → URGENCY canned question (eliminate 27s gap)
+
+**Files:**
+- Modify: `pipecat-agent/src/calllock/state_machine.py:236-247`
+- Test: `pipecat-agent/tests/test_state_machine.py`
+
+**Context:** When DISCOVERY detects all fields collected, it transitions to URGENCY with canned "Got it." and `needs_llm=False`. The next user input triggers an LLM call in URGENCY, but the LLM wastes a turn generating a summary instead of asking the urgency question. Fix: combine "Got it." with the urgency question in one canned speak.
+
+**Step 1: Write the failing test**
+
+Add to `TestDiscoveryState` class in `test_state_machine.py`:
+
+```python
+def test_all_fields_collected_emits_urgency_question(self, sm, session):
+    """When all fields known, canned speak should include urgency question."""
+    session.state = State.DISCOVERY
+    session.customer_name = "Jonas"
+    session.problem_description = "AC blowing warm air"
+    session.service_address = "4210 South Lamar Blvd"
+    action = sm.process(session, "")
+    assert session.state == State.URGENCY
+    assert action.needs_llm is False
+    assert "urgent" in action.speak.lower() or "today" in action.speak.lower()
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd pipecat-agent && pytest tests/test_state_machine.py::TestDiscoveryState::test_all_fields_collected_emits_urgency_question -v`
+Expected: FAIL — current `action.speak` is just "Got it." which doesn't contain "urgent" or "today".
+
+**Step 3: Update _handle_discovery**
+
+In `state_machine.py`, change `_handle_discovery` (line 246):
+
+```python
+# OLD:
+return Action(speak="Got it.", needs_llm=False)
+
+# NEW:
+return Action(
+    speak="Got it. How urgent is this - need someone today, or this week works?",
+    needs_llm=False,
+)
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd pipecat-agent && pytest tests/test_state_machine.py::TestDiscoveryState::test_all_fields_collected_emits_urgency_question -v`
+Expected: PASS
+
+**Step 5: Run full test suite**
+
+Run: `cd pipecat-agent && pytest tests/ -x -q`
+Expected: All tests pass. The existing `test_all_fields_routes_to_urgency` still passes (it only checks state, not speak).
+
+**Step 6: Commit**
+
+```bash
+git add pipecat-agent/src/calllock/state_machine.py pipecat-agent/tests/test_state_machine.py
+git commit -m "fix: emit canned urgency question from DISCOVERY to eliminate 27s dead air gap"
+```
+
+---
+
+### Task 3: Make _delayed_end_call cancellable (fix "1 more question")
+
+**Files:**
+- Modify: `pipecat-agent/src/calllock/processor.py:44-63,159,228,250-253`
+- Test: `pipecat-agent/tests/test_processor.py`
+
+**Context:** `_delayed_end_call` creates a fire-and-forget asyncio task. If the user speaks again during the delay, nothing can cancel it. Fix: store the task handle; cancel it if a new transcription arrives; re-enter the state machine with the new input.
+
+**Step 1: Write the failing test**
+
+Add to `test_processor.py`:
+
+```python
+class TestCancellableDelayedEnd:
+    """If user speaks again during delayed end, cancel the end and process new input."""
+
+    @pytest.mark.asyncio
+    async def test_new_transcription_cancels_delayed_end(self, processor):
+        """Speech during goodbye delay should cancel the end and process the new input."""
+        # Set up CONFIRM state, turn 2 (end_call=True, needs_llm=True)
+        processor.session.state = State.CONFIRM
+        processor.session.booking_confirmed = True
+        processor.session.confirmation_message = "Appointment confirmed for Wednesday at 3 PM"
+        # Simulate first turn
+        processor.session.state_turn_count = 1
+        processor.session.agent_has_responded = True
+
+        # Process "No." — this triggers _delayed_end_call
+        await processor.process_frame(
+            TranscriptionFrame(text="No.", user_id="", timestamp=""),
+            FrameDirection.DOWNSTREAM,
+        )
+
+        # Verify delayed end task was created
+        assert processor._end_call_task is not None
+        assert not processor._end_call_task.done()
+
+        # Now user speaks again before delay expires
+        await processor.process_frame(
+            TranscriptionFrame(text="Actually, how much is the diagnostic?", user_id="", timestamp=""),
+            FrameDirection.DOWNSTREAM,
+        )
+
+        # The old delayed end should be cancelled
+        assert processor._end_call_task is None or processor._end_call_task.cancelled()
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd pipecat-agent && pytest tests/test_processor.py::TestCancellableDelayedEnd::test_new_transcription_cancels_delayed_end -v`
+Expected: FAIL — `processor._end_call_task` attribute doesn't exist.
+
+**Step 3: Implement cancellable delayed end**
+
+In `processor.py`:
+
+3a. Add `_end_call_task` to `__init__` (after line 62):
+```python
+self._end_call_task: asyncio.Task | None = None
+```
+
+3b. Replace all `asyncio.create_task(self._delayed_end_call(...))` calls (lines 159, 228, 292) with:
+```python
+self._end_call_task = asyncio.create_task(self._delayed_end_call(delay=3.0))
+```
+(Keep the 4.0 delay on line 292 for terminal responses.)
+
+3c. Add cancellation logic at the top of `_handle_transcription` (after line 172, before state machine call):
+```python
+# Cancel pending delayed end if user speaks again
+if self._end_call_task and not self._end_call_task.done():
+    self._end_call_task.cancel()
+    self._end_call_task = None
+    logger.info(f"[{self.session.state.value}] Cancelled delayed end — user spoke again")
+```
+
+3d. Update `_delayed_end_call` to clear the reference after firing (line 250-253):
+```python
+async def _delayed_end_call(self, delay: float = 3.0):
+    """Push EndFrame after a delay to allow TTS to finish speaking."""
+    await asyncio.sleep(delay)
+    self._end_call_task = None
+    await self.push_frame(EndFrame(), FrameDirection.DOWNSTREAM)
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd pipecat-agent && pytest tests/test_processor.py::TestCancellableDelayedEnd -v`
+Expected: PASS
+
+**Step 5: Run full test suite**
+
+Run: `cd pipecat-agent && pytest tests/ -x -q`
+Expected: All tests pass.
+
+**Step 6: Commit**
+
+```bash
+git add pipecat-agent/src/calllock/processor.py pipecat-agent/tests/test_processor.py
+git commit -m "fix: make _delayed_end_call cancellable so user can still speak during goodbye"
+```
+
+---
+
+### Task 4: Move callback acknowledgment from SAFETY to URGENCY prompt
+
+**Files:**
+- Modify: `pipecat-agent/src/calllock/prompts.py:176-193,227-237`
+- Test: `pipecat-agent/tests/test_prompts.py`
+
+**Context:** SAFETY prompt says "acknowledge callback AFTER safety check" but the state machine transitions to SERVICE_AREA immediately after the user answers "No." The LLM never gets another SAFETY turn. URGENCY is the first LLM-generated state after the deterministic SERVICE_AREA/DISCOVERY flow.
+
+**Step 1: Write the failing test**
+
+Add to `test_prompts.py`:
+
+```python
+def test_urgency_prompt_includes_callback_acknowledgment(self):
+    """URGENCY prompt should acknowledge pending callback promise."""
+    session = CallSession(phone_number="+15125551234")
+    session.state = State.URGENCY
+    session.callback_promise = {"date": "today", "issue": "being really loud"}
+    prompt = get_system_prompt(session)
+    assert "callback" in prompt.lower()
+    assert "being really loud" in prompt.lower() or "callback" in prompt.lower()
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd pipecat-agent && pytest tests/test_prompts.py::test_urgency_prompt_includes_callback_acknowledgment -v`
+Expected: FAIL — URGENCY prompt doesn't mention callbacks. (Note: the callback data IS in KNOWN INFO via `_build_context`, but the URGENCY state prompt doesn't instruct the LLM to acknowledge it.)
+
+Actually, looking at the code again — `_build_context` (line 98-99) already includes `"We owe this caller a callback: ..."` in KNOWN INFO for ALL states. So the data is present. The issue is the URGENCY prompt doesn't tell the LLM to acknowledge it. Let me refine:
+
+```python
+def test_urgency_prompt_instructs_callback_acknowledgment(self):
+    """URGENCY state prompt text should tell LLM to acknowledge pending callback."""
+    session = CallSession(phone_number="+15125551234")
+    session.state = State.URGENCY
+    session.callback_promise = {"date": "today", "issue": "being really loud"}
+    prompt = get_system_prompt(session)
+    # The STATE_PROMPTS[URGENCY] text (not just KNOWN INFO) should mention callback
+    assert "callback" in STATE_PROMPTS[State.URGENCY].lower() or "owe" in STATE_PROMPTS[State.URGENCY].lower()
+```
+
+**Step 3: Update prompts**
+
+3a. Remove callback acknowledgment section from SAFETY prompt (lines 191-193):
+```python
+# REMOVE from State.SAFETY prompt:
+# CALLBACK ACKNOWLEDGMENT:
+# If KNOWN INFO mentions we owe this caller a callback, briefly acknowledge it AFTER the safety check:
+# "I also see we owe you a callback about [issue] - we'll make sure that gets handled too."
+```
+
+3b. Add callback acknowledgment to URGENCY prompt (line 237):
+```python
+State.URGENCY: """## URGENCY
+Determine scheduling priority.
+
+If KNOWN INFO mentions we owe this caller a callback, acknowledge it first:
+"I also see we owe you a callback about [issue] - we'll make sure that gets handled too."
+Then ask about urgency.
+
+If timing is ALREADY CLEAR from what they said:
+"ASAP" / "today" / "right away" -> urgent
+"whenever" / "this week" / "no rush" / specific day -> routine
+
+If timing is UNCLEAR:
+"How urgent is this - more of a 'need someone today' situation, or 'sometime in the next few days' works?"
+
+Do NOT say the time "works" or is "available" - you haven't checked the calendar yet.""",
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd pipecat-agent && pytest tests/test_prompts.py -v`
+Expected: PASS
+
+**Step 5: Run full test suite**
+
+Run: `cd pipecat-agent && pytest tests/ -x -q`
+Expected: All tests pass.
+
+**Step 6: Commit**
+
+```bash
+git add pipecat-agent/src/calllock/prompts.py pipecat-agent/tests/test_prompts.py
+git commit -m "fix: move callback acknowledgment from SAFETY to URGENCY prompt where LLM can deliver it"
+```
+
+---
+
+### Task 5: Em dash sanitizer for LLM-generated TTS text
+
+**Files:**
+- Modify: `pipecat-agent/src/calllock/processor.py:64-75`
+- Test: `pipecat-agent/tests/test_processor.py`
+
+**Context:** The LLM generates em dashes (`—`) in responses. Inworld TTS can crash with UTF-8 codec errors when em dashes land on streaming chunk boundaries. Fix: intercept all text going to TTS and replace em dashes with plain dashes.
+
+**Step 1: Write the failing test**
+
+Add to `test_processor.py`:
+
+```python
+class TestEmDashSanitizer:
+    """Em dashes in LLM output should be replaced before reaching TTS."""
+
+    @pytest.mark.asyncio
+    async def test_em_dash_replaced_in_tts_speak_frame(self, processor):
+        """TTSSpeakFrame text should have em dashes replaced with plain dashes."""
+        from pipecat.frames.frames import TTSSpeakFrame
+
+        processor.session.state = State.SAFETY
+        # Simulate a transcription that triggers a canned speak with em dash
+        # We test via process_frame pushing a TTSSpeakFrame through
+        frames_pushed = []
+        original_push = processor.push_frame
+
+        async def capture_push(frame, direction=FrameDirection.DOWNSTREAM):
+            frames_pushed.append(frame)
+            # Don't actually push downstream
+
+        processor.push_frame = capture_push
+
+        # Process a transcription that would generate a response
+        await processor.process_frame(
+            TranscriptionFrame(text="no gas smell", user_id="", timestamp=""),
+            FrameDirection.DOWNSTREAM,
+        )
+
+        # Check that any TTSSpeakFrame pushed has no em dashes
+        for frame in frames_pushed:
+            if isinstance(frame, TTSSpeakFrame):
+                assert "\u2014" not in frame.text  # em dash
+                assert "\u2013" not in frame.text  # en dash
+```
+
+**Step 2: Run test to verify current behavior**
+
+Run: `cd pipecat-agent && pytest tests/test_processor.py::TestEmDashSanitizer -v`
+Expected: May pass if no canned speaks have em dashes (they were already fixed). But the sanitizer protects against LLM-generated em dashes too.
+
+**Step 3: Add sanitizer to process_frame**
+
+In `processor.py`, add a helper method and modify `process_frame` to sanitize outbound text frames:
+
+3a. Add helper (after `__init__`):
+```python
+@staticmethod
+def _sanitize_tts_text(text: str) -> str:
+    """Replace em/en dashes with plain dashes to prevent Inworld TTS UTF-8 chunk errors."""
+    return text.replace("\u2014", "-").replace("\u2013", "-")
+```
+
+3b. Override `push_frame` to sanitize TTSSpeakFrame text before pushing:
+
+Actually, the cleaner approach is to sanitize at the two points where we create TTSSpeakFrame:
+- Line 202: `await self.push_frame(TTSSpeakFrame(text=action.speak), ...)`
+- Line 276: `await self.push_frame(TTSSpeakFrame(text=reply), ...)`
+- Line 285: `await self.push_frame(TTSSpeakFrame(text=canned), ...)`
+
+Replace each `TTSSpeakFrame(text=X)` with `TTSSpeakFrame(text=self._sanitize_tts_text(X))`.
+
+But we also need to catch LLM-generated text. The LLM output flows downstream as TextFrame through the context aggregator → LLM → TTS, bypassing this processor. So the sanitizer needs to be in the pipeline AFTER the LLM and BEFORE TTS.
+
+Simpler approach: add a small `TextSanitizer` frame processor between LLM and TTS in the pipeline. Let's add it to `pipeline.py` instead.
+
+**Revised approach — sanitize in pipeline.py:**
+
+3c. Create a simple sanitizer processor. Add to `processor.py` (bottom of file):
+
+```python
+class TextSanitizer(FrameProcessor):
+    """Replace em/en dashes in all text frames to prevent TTS UTF-8 errors."""
+
+    async def process_frame(self, frame: Frame, direction: FrameDirection):
+        await super().process_frame(frame, direction)
+        if isinstance(frame, TextFrame) and frame.text:
+            frame = TextFrame(text=frame.text.replace("\u2014", "-").replace("\u2013", "-"))
+        elif isinstance(frame, TTSSpeakFrame) and frame.text:
+            frame = TTSSpeakFrame(text=frame.text.replace("\u2014", "-").replace("\u2013", "-"))
+        await self.push_frame(frame, direction)
+```
+
+3d. Insert `TextSanitizer()` in the pipeline between LLM and TTS in `pipeline.py`. Find where the pipeline list is assembled and add it after the LLM output.
+
+**Step 4: Run tests**
+
+Run: `cd pipecat-agent && pytest tests/ -x -q`
+Expected: All tests pass.
+
+**Step 5: Commit**
+
+```bash
+git add pipecat-agent/src/calllock/processor.py pipecat-agent/src/calllock/pipeline.py pipecat-agent/tests/test_processor.py
+git commit -m "fix: sanitize em/en dashes before TTS to prevent UTF-8 chunk boundary crashes"
+```
+
+---
+
+### Task 6: Final verification and deploy
+
+**Step 1: Run full test suite**
+
+Run: `cd pipecat-agent && pytest tests/ -v`
+Expected: All tests pass.
+
+**Step 2: Push to remote**
+
+Run: `git push origin rbaset5/urgency-state-fixes`
+
+**Step 3: Deploy to Fly.io**
+
+Run: `cd pipecat-agent && fly deploy -a calllock-voice`
+
+**Step 4: Verify health**
+
+Run: `curl -s https://calllock-voice.fly.dev/health`
+Expected: `ok`
+
+**Step 5: Check logs for StartFrame noise**
+
+Run: `fly logs -a calllock-voice --no-tail | grep "StartFrame" | head -5`
+Expected: No StartFrame lines (filter working).
+
+**Step 6: Make a test call and verify**
+
+- Call should acknowledge callback promise during urgency question
+- DISCOVERY → URGENCY should be instant (canned question, no LLM delay)
+- Saying "No" then speaking again should cancel the goodbye
+- No em dash TTS crashes in logs

--- a/docs/plans/2026-02-24-call-quality-round2-design-review-outcome.md
+++ b/docs/plans/2026-02-24-call-quality-round2-design-review-outcome.md
@@ -1,0 +1,61 @@
+# Design Review Outcome — Call Quality Fixes Round 2
+
+**Date:** 2026-02-24
+**Plan reviewed:** `docs/plans/2026-02-24-call-quality-fixes-round2-plan.md`
+**Review type:** BIG CHANGE (4 sections, interactive)
+
+---
+
+## Overall Verdict
+
+The review caught a critical architecture conflict where two fixes would have silently cancelled each other out, eliminated an unnecessary pipeline component, fixed a type mismatch that would have made the canned acknowledgment hacky, and added 7 missing tests. The v1.0 plan had 5 independently-reasonable fixes that, when composed, contained a logical contradiction. The review caught it before implementation.
+
+## What It Nailed
+
+### The Architecture Conflict Caught
+
+v1.0 proposed Task 2 (canned urgency question from DISCOVERY with `needs_llm=False`) and Task 4 (callback acknowledgment moved to the URGENCY prompt, which is LLM-dependent) as independent fixes. In the happy path — user answers with "today" keyword — `_handle_urgency` catches the keyword deterministically and transitions to PRE_CONFIRM without ever calling the LLM. The URGENCY prompt, with its carefully-worded callback acknowledgment instruction, never fires. Two "fixes" that each looked correct in isolation would combine to guarantee the callback promise was never acknowledged — reproducing the exact bug they were supposed to fix.
+
+### The Key Insight
+
+Both the callback acknowledgment and the urgency question are deterministic data. We know the callback promise exists (from lookup result). We know the urgency question needs asking (all discovery fields collected). Neither requires LLM generation. Folding both into a single conditional canned speak from `_handle_discovery` matches the project's core principle perfectly: "code controls flow, LLM generates words." The callback acknowledgment becomes code-guaranteed delivery, not prompt-compliance-dependent.
+
+### The Over-Engineering Avoided
+
+v1.0 proposed a `TextSanitizer` — a full `FrameProcessor` subclass inserted into the 9-node pipeline between LLM and TTS — to replace em and en dashes with plain dashes. This new processor would have called `isinstance()` on every frame in the pipeline, including audio frames arriving at 50/sec, to do a 2-character string replacement on the occasional text frame. The review identified that `FallbackTTSService.run_tts()` already wraps every TTS call and is the natural single point for sanitization — 3 lines, no new class, no pipeline change.
+
+### The Delta (Before vs. After)
+
+| Aspect | v1.0 | v1.1 |
+|--------|------|------|
+| New classes | 1 (`TextSanitizer` pipeline processor) | 0 |
+| Pipeline nodes | 10 (added 1) | 9 (unchanged) |
+| Conflicting fixes | 2 (Task 2 + Task 4 silently cancel) | 0 (merged into single mechanism) |
+| Tests in plan | 3 | 10 (filter: 3, cancellation: 4, edge case: 1, callback: 2) |
+| `callback_promise` type | `str` storing a dict, ugly prompt rendering | `dict` with proper rendering |
+| `logger.remove()` blast radius | All loguru handlers | Handler ID 0 only |
+| Em dash sanitizer location | New pipeline processor (every frame) | Inside existing `run_tts` (text only) |
+| Cancellation bound | Unbounded (infinite re-trigger possible) | Exactly 1 via `confirm_extended` flag |
+
+## The Final Plan (v1.1)
+
+1. **Loguru filter** — `logger.remove(0)` with try/except + `logger.add(filter=...)`. 3 unit tests for filter function.
+
+2. **Canned urgency question with conditional callback ack** — `_handle_discovery` emits callback acknowledgment + urgency question as one canned speak when all fields known. `URGENCY_QUESTION` extracted as module constant. `callback_promise` type changed from `str` to `dict` with clean rendering in `_build_context`. SAFETY prompt callback instruction removed (unreachable).
+
+3. **Cancellable delayed end with `confirm_extended` flag** — `_end_call_task` stored on processor, cancelled on new transcription. First cancellation allowed (sets `confirm_extended=True`), second cancellation blocked (call ends). 4 tests: succeed, blocked, downstream push verified, race edge case documented.
+
+4. **Em dash sanitizer in `FallbackTTSService.run_tts`** — `text = text.replace("\u2014", "-").replace("\u2013", "-")` before passing to primary/fallback. No new class.
+
+5. **Remove callback ack from SAFETY prompt** — instruction was unreachable (state machine transitions before LLM fires).
+
+## Scope Boundaries
+
+| Not in scope | Why | When it might matter |
+|-------------|-----|---------------------|
+| ZIP code misinterpretation ("5211" as ZIP) | Transcription/UX issue, not state machine bug | If misrouting shows up frequently in call analytics |
+| "Wrap sound" transcription quality | Deepgram STT limitation, not fixable in our code | When Deepgram ships telephony-optimized models |
+| Redundant urgency question when already expressed | Extraction runs async, may not be done; 2s redundancy acceptable | When extraction becomes synchronous or guaranteed-complete |
+| CONFIRM Turn 3+ redesign | One cancellation covers "changed my mind"; per-state limit catches abuse | If analytics show frequent multi-question close sequences |
+| Pipecat loguru deprecation warnings | Cosmetic, from pipecat's internal API migration | When upgrading pipecat to next major version |
+| StartFrame errors (cosmetic) | Prior review proved these are non-functional; `run_tts` yields via generators, bypassing `push_frame` | When Pipecat fixes inner-service StartFrame propagation |

--- a/pipecat-agent/src/calllock/bot.py
+++ b/pipecat-agent/src/calllock/bot.py
@@ -10,12 +10,28 @@ logging.basicConfig(
 )
 
 # Suppress Pipecat "StartFrame not received" cosmetic noise that floods Fly.io log buffer.
-# Uses a targeted filter (not setLevel) to preserve real frame processor errors.
-class _StartFrameNoiseFilter(logging.Filter):
-    def filter(self, record: logging.LogRecord) -> bool:
-        return "StartFrame not received" not in record.getMessage()
+# Pipecat uses loguru (not stdlib logging), so we must filter at the loguru level.
+import sys
+from loguru import logger as _loguru
 
-logging.getLogger("pipecat.processors.frame_processor").addFilter(_StartFrameNoiseFilter())
+
+def _startframe_noise_filter(record):
+    """Suppress 'StartFrame not received' from pipecat.processors.frame_processor only."""
+    if record["name"] == "pipecat.processors.frame_processor":
+        return "StartFrame not received" not in record["message"]
+    return True
+
+
+try:
+    _loguru.remove(0)  # Remove default handler only (not other sinks)
+except ValueError:
+    pass  # Already removed by another module
+_loguru.add(
+    sys.stderr,
+    filter=_startframe_noise_filter,
+    level="DEBUG",
+    format="{time:YYYY-MM-DD HH:mm:ss.SSS} | {level: <8} | {name}:{function}:{line} - {message}",
+)
 
 import uvicorn  # noqa: E402
 from dotenv import load_dotenv  # noqa: E402

--- a/pipecat-agent/src/calllock/bot.py
+++ b/pipecat-agent/src/calllock/bot.py
@@ -9,6 +9,14 @@ logging.basicConfig(
     datefmt="%Y-%m-%d %H:%M:%S",
 )
 
+# Suppress Pipecat "StartFrame not received" cosmetic noise that floods Fly.io log buffer.
+# Uses a targeted filter (not setLevel) to preserve real frame processor errors.
+class _StartFrameNoiseFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        return "StartFrame not received" not in record.getMessage()
+
+logging.getLogger("pipecat.processors.frame_processor").addFilter(_StartFrameNoiseFilter())
+
 import uvicorn  # noqa: E402
 from dotenv import load_dotenv  # noqa: E402
 from fastapi import FastAPI, Request, WebSocket  # noqa: E402

--- a/pipecat-agent/src/calllock/prompts.py
+++ b/pipecat-agent/src/calllock/prompts.py
@@ -65,7 +65,7 @@ STOP AFTER "Anything else?" — wait for the caller to respond.
 SECOND RESPONSE (after caller replies):
 - If they ask about price: "It's an $89 diagnostic, and if you go ahead with the repair we knock that off."
 - If they ask what to do: give brief practical advice (close blinds, grab a fan, put a bucket).
-- Then close: "Alright, thanks for calling ACE Cooling — stay cool out there."
+- Then close: "Alright, thanks for calling ACE Cooling - stay cool out there."
 """
 
 
@@ -186,7 +186,11 @@ AMBIGUOUS: ONE follow-up: "Just to be safe — right this second, are you smelli
 
 "Gas heater" + "water leak" = NOT emergency.
 "Gas heater" + "smells like gas" = YES emergency.
-Only their answer about RIGHT NOW determines safety.""",
+Only their answer about RIGHT NOW determines safety.
+
+CALLBACK ACKNOWLEDGMENT:
+If KNOWN INFO mentions we owe this caller a callback, briefly acknowledge it AFTER the safety check:
+"I also see we owe you a callback about [issue] - we'll make sure that gets handled too.""",
 
     State.SAFETY_EXIT: """## SAFETY EMERGENCY
 Say EXACTLY: "Okay — this is a safety emergency. I need you to leave the house right now and call 911 from outside. Don't flip any light switches on the way out. Stay safe."

--- a/pipecat-agent/src/calllock/prompts.py
+++ b/pipecat-agent/src/calllock/prompts.py
@@ -96,7 +96,9 @@ def _build_context(session: CallSession) -> str:
     if session.caller_known:
         parts.append("Returning caller (known customer)")
     if session.callback_promise:
-        parts.append(f"We owe this caller a callback: {session.callback_promise}")
+        issue = session.callback_promise.get("issue", "unknown issue")
+        date = session.callback_promise.get("date", "")
+        parts.append(f"We owe this caller a callback about {issue}" + (f" (from {date})" if date else ""))
     if session.lead_type == "high_ticket":
         parts.append("HIGH-TICKET LEAD: Caller wants replacement/new system")
     if session.is_third_party:
@@ -188,9 +190,7 @@ AMBIGUOUS: ONE follow-up: "Just to be safe — right this second, are you smelli
 "Gas heater" + "smells like gas" = YES emergency.
 Only their answer about RIGHT NOW determines safety.
 
-CALLBACK ACKNOWLEDGMENT:
-If KNOWN INFO mentions we owe this caller a callback, briefly acknowledge it AFTER the safety check:
-"I also see we owe you a callback about [issue] - we'll make sure that gets handled too.""",
+Do NOT mention callbacks or callback promises — that is handled automatically in the next step.""",
 
     State.SAFETY_EXIT: """## SAFETY EMERGENCY
 Say EXACTLY: "Okay — this is a safety emergency. I need you to leave the house right now and call 911 from outside. Don't flip any light switches on the way out. Stay safe."
@@ -227,14 +227,16 @@ When all three items are collected, STOP. Say nothing about next steps. The syst
     State.URGENCY: """## URGENCY
 Determine scheduling priority.
 
+If KNOWN INFO mentions we owe this caller a callback, acknowledge it briefly first.
+
 If timing is ALREADY CLEAR from what they said:
 "ASAP" / "today" / "right away" -> urgent
 "whenever" / "this week" / "no rush" / specific day -> routine
 
 If timing is UNCLEAR:
-"How urgent is this — more of a 'need someone today' situation, or 'sometime in the next few days' works?"
+"How urgent is this - more of a 'need someone today' situation, or 'sometime in the next few days' works?"
 
-Do NOT say the time "works" or is "available" — you haven't checked the calendar yet.""",
+Do NOT say the time "works" or is "available" - you haven't checked the calendar yet.""",
 
     State.URGENCY_CALLBACK: """## URGENCY CALLBACK
 Handle callback requests and high-ticket sales lead routing.

--- a/pipecat-agent/src/calllock/session.py
+++ b/pipecat-agent/src/calllock/session.py
@@ -16,7 +16,7 @@ class CallSession:
     appointment_date: str = ""
     appointment_time: str = ""
     appointment_uid: str = ""
-    callback_promise: str = ""
+    callback_promise: dict = field(default_factory=dict)
     caller_intent: str = ""  # hvac_issue, schedule_service, follow_up, manage_appointment, unclear
 
     # From discovery
@@ -49,6 +49,7 @@ class CallSession:
 
     # Terminal state response control
     terminal_reply_used: bool = False
+    confirm_extended: bool = False  # True after first delayed-end cancellation in CONFIRM
 
     # Call metadata
     call_sid: str = ""

--- a/pipecat-agent/src/calllock/state_machine.py
+++ b/pipecat-agent/src/calllock/state_machine.py
@@ -94,7 +94,7 @@ YES_SIGNALS = frozenset({
     "correct", "that's right", "go ahead",
 })
 CONFIRM_CLOSE_SIGNALS = frozenset({
-    "no", "nope", "nah", "thanks", "thank you", "bye", "goodbye",
+    "thanks", "thank you", "bye", "goodbye",
     "that's it", "that's all", "all good", "i'm good", "nothing else",
 })
 
@@ -327,7 +327,7 @@ class StateMachine:
         if match_any_keyword(text, CONFIRM_CLOSE_SIGNALS) or not text.strip():
             # Common close -> canned response, skip LLM
             return Action(
-                speak="Alright, thanks for calling ACE Cooling — stay cool out there.",
+                speak="Alright, thanks for calling ACE Cooling - stay cool out there.",
                 end_call=True,
                 needs_llm=False,
             )

--- a/pipecat-agent/src/calllock/tts_fallback.py
+++ b/pipecat-agent/src/calllock/tts_fallback.py
@@ -105,6 +105,9 @@ class FallbackTTSService(TTSService):
         return self._primary.can_generate_metrics()
 
     async def run_tts(self, text: str, context_id: str) -> AsyncGenerator[Frame, None]:
+        # Sanitize em/en dashes to prevent Inworld TTS UTF-8 chunk boundary errors
+        text = text.replace("\u2014", "-").replace("\u2013", "-")
+
         if self._circuit.should_try():
             async for frame in self._try_primary(text, context_id):
                 yield frame

--- a/pipecat-agent/tests/test_bot.py
+++ b/pipecat-agent/tests/test_bot.py
@@ -1,0 +1,20 @@
+from unittest.mock import patch
+
+# bot.py calls validate_config() at import time, which sys.exit(1) if env vars missing.
+# Patch it so the import succeeds in test environment.
+with patch("calllock.config.validate_config"):
+    from calllock.bot import _startframe_noise_filter
+
+
+class TestStartFrameNoiseFilter:
+    def test_suppresses_startframe_from_frame_processor(self):
+        record = {"name": "pipecat.processors.frame_processor", "message": "InworldHttpTTSService#0 Trying to process TTSTextFrame but StartFrame not received yet"}
+        assert _startframe_noise_filter(record) is False
+
+    def test_allows_real_errors_from_frame_processor(self):
+        record = {"name": "pipecat.processors.frame_processor", "message": "Real error in frame processing"}
+        assert _startframe_noise_filter(record) is True
+
+    def test_allows_startframe_text_from_other_modules(self):
+        record = {"name": "calllock.processor", "message": "StartFrame not received"}
+        assert _startframe_noise_filter(record) is True

--- a/pipecat-agent/tests/test_processor.py
+++ b/pipecat-agent/tests/test_processor.py
@@ -127,10 +127,12 @@ class TestEndCallAfterLLM:
     @pytest.mark.asyncio
     async def test_end_call_with_llm_schedules_endframe(self, processor):
         """When end_call=True and needs_llm=True, EndFrame should be scheduled after delay."""
-        # Put session in CONFIRM state — triggers end_call=True, needs_llm=True
+        # Put session in CONFIRM state second turn — triggers end_call=True, needs_llm=True
         processor.session.state = State.CONFIRM
+        processor.session.state_turn_count = 1
+        processor.session.agent_has_responded = True
 
-        frame = TranscriptionFrame(text="Thanks bye", user_id="", timestamp="")
+        frame = TranscriptionFrame(text="How much does the diagnostic cost?", user_id="", timestamp="")
         await processor._handle_transcription(frame)
 
         # Transcription frame should be pushed downstream for LLM

--- a/pipecat-agent/tests/test_prompts.py
+++ b/pipecat-agent/tests/test_prompts.py
@@ -174,20 +174,24 @@ class TestBuildContextBookingDetails:
         assert "Monday, February 24" not in context
 
 
-class TestCallbackPromiseInSafety:
-    """Callback promise should appear in SAFETY prompt for service-intent callers."""
+class TestCallbackPromiseRendering:
+    """Callback promise should render cleanly in KNOWN INFO."""
 
-    def test_safety_prompt_includes_callback_promise(self):
+    def test_callback_promise_renders_issue(self):
         session = CallSession(phone_number="+15125551234")
         session.state = State.SAFETY
-        session.callback_promise = "{'date': 'today', 'issue': 'being really loud'}"
+        session.callback_promise = {"date": "today", "issue": "being really loud"}
         prompt = get_system_prompt(session)
-        assert "callback" in prompt.lower()
         assert "being really loud" in prompt
+        assert "callback" in prompt.lower()
 
-    def test_safety_prompt_without_promise_unchanged(self):
+    def test_callback_promise_empty_dict_excluded(self):
         session = CallSession(phone_number="+15125551234")
         session.state = State.SAFETY
-        session.callback_promise = ""
+        session.callback_promise = {}
         prompt = get_system_prompt(session)
-        assert "we owe this caller a callback:" not in prompt.lower()
+        assert "we owe this caller" not in prompt.lower()
+
+    def test_safety_prompt_no_longer_has_callback_instruction(self):
+        """SAFETY prompt should NOT contain callback acknowledgment instruction (moved to canned speak)."""
+        assert "CALLBACK ACKNOWLEDGMENT" not in STATE_PROMPTS[State.SAFETY]

--- a/pipecat-agent/tests/test_prompts.py
+++ b/pipecat-agent/tests/test_prompts.py
@@ -105,6 +105,33 @@ class TestAppointmentContextGating:
         assert "2026-02-20" in prompt
 
 
+class TestDiscoveryPromptBoundary:
+    def test_discovery_prompt_forbids_timing_and_states_auto_transition(self):
+        """DISCOVERY prompt must forbid timing and mention automatic transition."""
+        session = CallSession(phone_number="+15125551234")
+        session.state = State.DISCOVERY
+        prompt = get_system_prompt(session)
+        assert "Do NOT ask about timing" in prompt
+        assert "transitions automatically" in prompt
+
+
+class TestConfirmTwoTurnPrompt:
+    def test_confirm_prompt_has_two_turn_structure(self):
+        """CONFIRM prompt must have FIRST RESPONSE and SECOND RESPONSE sections."""
+        session = CallSession(phone_number="+15125551234")
+        session.state = State.CONFIRM
+        session.confirmation_message = "Wednesday at 9:00 AM"
+        prompt = get_system_prompt(session)
+        assert "FIRST RESPONSE" in prompt
+        assert "SECOND RESPONSE" in prompt
+        assert "EXACT date and time" in prompt
+
+    def test_confirm_prompt_is_single_source(self):
+        """STATE_PROMPTS[CONFIRM] should not exist — _confirm_prompt is the source."""
+        from calllock.prompts import STATE_PROMPTS
+        assert State.CONFIRM not in STATE_PROMPTS
+
+
 class TestConfirmPromptInjection:
     def test_confirm_prompt_includes_booking_details(self):
         session = CallSession(phone_number="+15125551234")

--- a/pipecat-agent/tests/test_prompts.py
+++ b/pipecat-agent/tests/test_prompts.py
@@ -172,3 +172,22 @@ class TestBuildContextBookingDetails:
 
         context = _build_context(session)
         assert "Monday, February 24" not in context
+
+
+class TestCallbackPromiseInSafety:
+    """Callback promise should appear in SAFETY prompt for service-intent callers."""
+
+    def test_safety_prompt_includes_callback_promise(self):
+        session = CallSession(phone_number="+15125551234")
+        session.state = State.SAFETY
+        session.callback_promise = "{'date': 'today', 'issue': 'being really loud'}"
+        prompt = get_system_prompt(session)
+        assert "callback" in prompt.lower()
+        assert "being really loud" in prompt
+
+    def test_safety_prompt_without_promise_unchanged(self):
+        session = CallSession(phone_number="+15125551234")
+        session.state = State.SAFETY
+        session.callback_promise = ""
+        prompt = get_system_prompt(session)
+        assert "we owe this caller a callback:" not in prompt.lower()


### PR DESCRIPTION
## Summary
- **Timezone fix**: Extracted `formatBookingTime()` helper with `America/Chicago` timezone — Render's UTC server was producing wrong times in booking confirmations
- **CONFIRM two-turn flow**: First turn confirms appointment + "Anything else?", second turn uses canned close for "no/thanks" or LLM for actual questions
- **DISCOVERY boundary**: Returns `needs_llm=False` + canned "Got it." when all fields pre-populated, preventing LLM from asking timing questions
- **Urgency keywords**: Added `urgent`, `immediately`, `earliest`, `soon as possible` to URGENT_SIGNALS

## Test plan
- [x] V2: 194 tests pass (3 new for `formatBookingTime()`)
- [x] Pipecat: 407 tests pass (16 new across state machine, prompts, processor)
- [ ] Deploy V2 to Render first, verify booking times show CST
- [ ] Deploy pipecat-agent to Fly.io, verify CONFIRM pauses after "Anything else?"
- [ ] Test call: urgency detected on "urgent", "immediately", "earliest"

🤖 Generated with [Claude Code](https://claude.com/claude-code)